### PR TITLE
Fix: Remove leftover Gemini configuration causing Pydantic validation error

### DIFF
--- a/FIX_GEMINI_CONFIG.md
+++ b/FIX_GEMINI_CONFIG.md
@@ -1,0 +1,26 @@
+# Fix: Gemini Configuration Issue
+
+## Problem
+The application was failing with a Pydantic validation error:
+```
+Fatal error: 1 validation error for Settings
+gemini_api_key
+  Extra inputs are not permitted
+```
+
+## Root Cause
+The `.env` file contained a `GEMINI_API_KEY` that was added during incomplete Gemini integration work from the grid-zoom-implementation branch. The Settings model in `src/config/settings.py` does not have a `gemini_api_key` field, and Pydantic's strict mode rejects extra environment variables.
+
+## Solution
+1. Removed `GEMINI_API_KEY` from `.env` file
+2. Removed leftover `src/models/__pycache__/gemini_client.cpython-312.pyc` file
+3. No Gemini source code exists in the main branch, so complete removal was the cleanest approach
+
+## Files Changed
+- `.env` - Removed Gemini configuration section (not tracked in git)
+- Deleted `src/models/__pycache__/gemini_client.cpython-312.pyc` (not tracked in git)
+
+## Testing
+Confirmed the application runs without errors:
+- `python -m src.main --version` ✓
+- `python -m src.main --plan test_scenarios/wikipedia_search_simple.txt --plan-only` ✓


### PR DESCRIPTION
## Summary
Fixes the Pydantic validation error that was preventing the application from starting.

## Problem
The application was failing with:
```
Fatal error: 1 validation error for Settings
gemini_api_key
  Extra inputs are not permitted
```

## Root Cause
- The `.env` file contained `GEMINI_API_KEY` from incomplete Gemini integration work
- The Settings model doesn't have a `gemini_api_key` field
- Pydantic's strict mode rejects extra environment variables

## Solution
Since no Gemini integration code exists in the main branch, the cleanest solution was to remove all Gemini remnants:
1. Removed `GEMINI_API_KEY` from `.env` file
2. Removed leftover `gemini_client.cpython-312.pyc` file
3. Added documentation explaining the issue and fix

## Testing
✅ Application now starts without errors:
- `python -m src.main --version` works
- `python -m src.main --plan test_scenarios/wikipedia_search_simple.txt --plan-only` works

## Note
The actual fixes were in gitignored files (.env and __pycache__), so this PR primarily adds documentation of the issue and its resolution for future reference.