### PR TITLE
Streamline plan-only workflow

### DIFF
--- a/src/agents/formatters.py
+++ b/src/agents/formatters.py
@@ -69,7 +69,6 @@ class TestPlanFormatter:
         
         # Metadata
         lines.append(f"**Description**: {test_plan.description}")
-        lines.append(f"**Created**: {test_plan.created_at.strftime('%Y-%m-%d %H:%M UTC')}")
         lines.append(f"**Requirements Source**: {test_plan.requirements_source}")
         if test_plan.tags:
             lines.append(f"**Tags**: {', '.join(test_plan.tags)}")


### PR DESCRIPTION
## Summary
- skip browser bootstrap when running with --plan-only and show a waiting spinner while GPT-5 generates plans
- print generated_test_plans directory + filenames after plan creation and strip embedded URLs from plan inputs
- drop the Created field from markdown plans and extend CLI tests to cover plan-only behaviour

## Testing
- python -m src.main --plan test_scenarios/wikipedia_search_simple.txt --plan-only
- pytest tests/test_main.py
