### PR TITLE
Declare missing Jinja dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "numpy>=1.24.0",
     "aiofiles>=23.2.1",
     "jsonlines>=4.0.0",
+    "jinja2>=3.1.0",
     "tiktoken>=0.5.1",
 ]
 


### PR DESCRIPTION
## Summary
- add jinja2 to the core dependency list so monitoring reports can import it
- confirm no other site-packages imports are missing from pyproject.toml

## Testing
- pip install -e .
- python -m src.main --plan-only --plan test_scenarios/wikipedia_search_simple.txt
