### PR TITLE
Show streaming token progress during planning

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from src.core.interfaces import Agent
 from src.core.types import AgentMessage, ConfidenceLevel
-from src.models.openai_client import OpenAIClient
+from src.models.openai_client import OpenAIClient, ResponseStreamObserver
 
 
 class BaseAgent(Agent):
@@ -158,6 +158,8 @@ class BaseAgent(Agent):
         response_format: Optional[Dict[str, Any]] = None,
         reasoning_level: Optional[str] = None,
         modalities: Optional[Set[str]] = None,
+        stream: bool = False,
+        stream_observer: Optional[ResponseStreamObserver] = None,
     ) -> Dict[str, Any]:
         """
         Make a call to OpenAI API.
@@ -166,6 +168,8 @@ class BaseAgent(Agent):
             messages: List of message dictionaries
             temperature: Override default temperature
             response_format: Optional response format specification
+            stream: Enable streaming Responses API integration
+            stream_observer: Optional observer for streaming events
 
         Returns:
             API response
@@ -177,6 +181,8 @@ class BaseAgent(Agent):
             response_format=response_format,
             reasoning_level=reasoning_level or self.reasoning_level,
             modalities=modalities or self.modalities,
+            stream=stream,
+            stream_observer=stream_observer,
         )
 
     def update_reasoning_level(self, level: str) -> None:

--- a/src/models/openai_client.py
+++ b/src/models/openai_client.py
@@ -2,12 +2,39 @@
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Set
+import math
+import inspect
+from typing import Any, Dict, List, Optional, Sequence, Set, Protocol
 
 import openai
 from openai import AsyncOpenAI
 
 from src.config.settings import get_settings
+
+
+class ResponseStreamObserver(Protocol):
+    """Observer that receives streaming updates from the Responses API."""
+
+    def on_stream_start(self) -> Any:
+        ...
+
+    def on_text_delta(self, delta: str) -> Any:
+        ...
+
+    def on_usage_delta(self, delta: Dict[str, int]) -> Any:
+        ...
+
+    def on_usage_total(self, totals: Dict[str, int]) -> Any:
+        ...
+
+    def on_token_progress(self, total_tokens: int, delta_tokens: int, delta_chars: int) -> Any:
+        ...
+
+    def on_error(self, error: Any) -> Any:
+        ...
+
+    def on_stream_end(self) -> Any:
+        ...
 
 
 class OpenAIClient:
@@ -35,6 +62,7 @@ class OpenAIClient:
         self.reasoning_level = reasoning_level
         self.modalities = modalities or {"text"}
         self.logger = logging.getLogger("openai_client")
+        self._token_encoder_cache: Dict[str, Any] = {}
 
         settings = get_settings()
         self.api_key = api_key or settings.openai_api_key
@@ -61,6 +89,8 @@ class OpenAIClient:
         response_format: Optional[Dict[str, Any]] = None,
         reasoning_level: Optional[str] = None,
         modalities: Optional[Set[str]] = None,
+        stream: bool = False,
+        stream_observer: Optional["ResponseStreamObserver"] = None,
     ) -> Dict[str, Any]:
         """Make a call to the OpenAI API."""
 
@@ -78,6 +108,23 @@ class OpenAIClient:
 
         try:
             if use_responses:
+                if stream or stream_observer is not None:
+                    try:
+                        return await self._call_responses_api_streaming(
+                            final_messages=final_messages,
+                            temperature=temperature,
+                            max_tokens=max_tokens,
+                            response_format=response_format,
+                            reasoning_level=reasoning_level or self.reasoning_level,
+                            system_prompt=system_prompt,
+                            observer=stream_observer,
+                        )
+                    except Exception as stream_error:
+                        self.logger.warning(
+                            "Streaming responses call failed; falling back to standard execution",
+                            exc_info=True,
+                        )
+
                 return await self._call_responses_api(
                     final_messages=final_messages,
                     temperature=temperature,
@@ -366,6 +413,139 @@ class OpenAIClient:
             "finish_reason": finish_reason,
         }
 
+    async def _call_responses_api_streaming(
+        self,
+        final_messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: Optional[int],
+        response_format: Optional[Dict[str, Any]],
+        reasoning_level: Optional[str],
+        system_prompt: Optional[str],
+        observer: Optional[ResponseStreamObserver],
+    ) -> Dict[str, Any]:
+        instructions, input_items = self._prepare_responses_input(final_messages, system_prompt)
+
+        kwargs: Dict[str, Any] = {
+            "model": self.model,
+            "input": input_items,
+        }
+
+        if instructions:
+            kwargs["instructions"] = instructions
+
+        if max_tokens:
+            kwargs["max_output_tokens"] = max_tokens
+
+        text_config = self._map_response_format_to_text_config(response_format)
+        if text_config:
+            kwargs["text"] = text_config
+
+        if reasoning_level:
+            kwargs["reasoning"] = {"effort": reasoning_level}
+
+        if self._supports_responses_temperature(self.model):
+            kwargs["temperature"] = temperature
+
+        usage_totals = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        last_reported_usage = dict(usage_totals)
+        token_encoder = self._get_token_encoder(self.model)
+        estimated_output_tokens = 0
+
+        await self._dispatch_observer(observer, "on_stream_start")
+
+        final_response: Any = None
+
+        try:
+            async with self.client.responses.stream(
+                timeout=self.request_timeout,
+                **kwargs,
+            ) as stream:
+                async for event in stream:
+                    event_type = getattr(event, "type", "")
+
+                    if event_type == "response.output_text.delta":
+                        delta_text = self._resolve_text_delta(getattr(event, "delta", None))
+                        if delta_text:
+                            await self._dispatch_observer(observer, "on_text_delta", delta_text)
+                            delta_chars = len(delta_text)
+                            delta_tokens = self._estimate_token_count(delta_text, token_encoder)
+                            if delta_tokens:
+                                estimated_output_tokens += delta_tokens
+                            await self._dispatch_observer(
+                                observer,
+                                "on_token_progress",
+                                estimated_output_tokens,
+                                delta_tokens,
+                                delta_chars,
+                            )
+                    elif event_type in {"response.in_progress", "response.completed"}:
+                        usage_payload = self._extract_usage_from_event(event)
+                        if usage_payload:
+                            delta_payload = self._calculate_usage_delta(
+                                last_reported_usage, usage_payload
+                            )
+                            usage_totals.update(usage_payload)
+                            last_reported_usage.update(usage_payload)
+                            if delta_payload:
+                                await self._dispatch_observer(
+                                    observer, "on_usage_delta", delta_payload
+                                )
+                    elif event_type == "response.error":
+                        error = getattr(event, "error", None)
+                        if error is not None:
+                            await self._dispatch_observer(observer, "on_error", error)
+
+                final_response = await stream.get_final_response()
+        except Exception as error:
+            await self._dispatch_observer(observer, "on_error", error)
+            await self._dispatch_observer(observer, "on_stream_end")
+            raise
+
+        if final_response is None:
+            raise RuntimeError("Streaming response did not return a final result")
+
+        content_text = self._extract_output_text(final_response)
+        usage = getattr(final_response, "usage", None)
+
+        combined_usage = dict(usage_totals)
+        for key in list(combined_usage.keys()):
+            final_value = self._safe_usage_lookup(usage, key)
+            if final_value:
+                combined_usage[key] = max(combined_usage[key], final_value)
+
+        if estimated_output_tokens:
+            combined_usage["output_tokens"] = max(
+                combined_usage.get("output_tokens", 0), estimated_output_tokens
+            )
+            combined_usage["total_tokens"] = max(
+                combined_usage.get("total_tokens", 0), estimated_output_tokens
+            )
+
+        await self._dispatch_observer(observer, "on_usage_total", combined_usage)
+        await self._dispatch_observer(observer, "on_stream_end")
+
+        usage_dict = {
+            "prompt_tokens": combined_usage.get("input_tokens", 0),
+            "completion_tokens": combined_usage.get("output_tokens", 0),
+            "total_tokens": combined_usage.get("total_tokens", 0),
+        }
+
+        if response_format and response_format.get("type") == "json_object":
+            try:
+                content_text = json.loads(content_text)
+            except json.JSONDecodeError as exc:
+                self.logger.error(f"Failed to parse JSON response: {exc}")
+                content_text = {"error": "Invalid JSON response", "raw": content_text}
+
+        finish_reason = getattr(final_response, "status", None)
+
+        return {
+            "content": content_text,
+            "usage": usage_dict,
+            "model": getattr(final_response, "model", self.model),
+            "finish_reason": finish_reason,
+        }
+
     def _prepare_responses_input(
         self,
         final_messages: Sequence[Dict[str, Any]],
@@ -449,6 +629,40 @@ class OpenAIClient:
             return int(usage.get(key, 0))
         return int(getattr(usage, key, 0))
 
+    def _get_token_encoder(self, model: str) -> Optional[Any]:
+        if model in self._token_encoder_cache:
+            return self._token_encoder_cache[model]
+
+        try:
+            import tiktoken  # type: ignore
+        except ImportError:
+            self._token_encoder_cache[model] = None
+            return None
+
+        try:
+            encoder = tiktoken.encoding_for_model(model)
+        except KeyError:
+            try:
+                encoder = tiktoken.get_encoding("cl100k_base")
+            except Exception:
+                encoder = None
+
+        self._token_encoder_cache[model] = encoder
+        return encoder
+
+    def _estimate_token_count(self, text: str, encoder: Optional[Any]) -> int:
+        if not text:
+            return 0
+
+        if encoder is not None:
+            try:
+                return len(encoder.encode(text))
+            except Exception:
+                pass
+
+        # Fallback heuristic: roughly 4 characters per token.
+        return max(1, math.ceil(len(text) / 4))
+
     def _map_response_format_to_text_config(
         self, response_format: Optional[Dict[str, Any]]
     ) -> Optional[Dict[str, Any]]:
@@ -469,3 +683,90 @@ class OpenAIClient:
             return {"format": {"type": "text"}}
 
         return None
+
+    async def _dispatch_observer(
+        self,
+        observer: Optional[ResponseStreamObserver],
+        method_name: str,
+        *args: Any,
+    ) -> None:
+        if observer is None:
+            return
+
+        method = getattr(observer, method_name, None)
+        if method is None:
+            return
+
+        try:
+            result = method(*args)
+        except Exception as observer_error:  # pragma: no cover - defensive logging
+            self.logger.debug(
+                "Streaming observer %s raised an exception: %s",
+                method_name,
+                observer_error,
+            )
+            return
+
+        if inspect.isawaitable(result):
+            await result
+
+    def _extract_usage_from_event(self, event: Any) -> Dict[str, int]:
+        response_obj = getattr(event, "response", None)
+        if response_obj is None:
+            return {}
+
+        usage_obj = getattr(response_obj, "usage", None)
+        return self._normalize_usage_dict(usage_obj)
+
+    def _calculate_usage_delta(
+        self, previous: Dict[str, int], current: Dict[str, int]
+    ) -> Dict[str, int]:
+        delta: Dict[str, int] = {}
+        for key in ("input_tokens", "output_tokens", "total_tokens"):
+            new_value = int(current.get(key, previous.get(key, 0)) or 0)
+            old_value = int(previous.get(key, 0) or 0)
+            difference = new_value - old_value
+            if difference > 0:
+                delta[key] = difference
+        return delta
+
+    def _normalize_usage_dict(self, usage: Any) -> Dict[str, int]:
+        payload: Dict[str, int] = {}
+        if usage is None:
+            return payload
+
+        for key in ("input_tokens", "output_tokens", "total_tokens"):
+            value: Optional[int]
+            if isinstance(usage, dict):
+                value = usage.get(key)
+            else:
+                value = getattr(usage, key, None)
+
+            if value is None:
+                continue
+
+            try:
+                payload[key] = int(value)
+            except (TypeError, ValueError):
+                continue
+
+        return payload
+
+    def _resolve_text_delta(self, delta: Any) -> str:
+        if delta is None:
+            return ""
+        if isinstance(delta, str):
+            return delta
+        if isinstance(delta, dict):
+            text_value = delta.get("text") or delta.get("output_text")
+            return str(text_value) if text_value else ""
+
+        text_attr = getattr(delta, "text", None)
+        if text_attr:
+            return str(text_attr)
+
+        output_attr = getattr(delta, "output_text", None)
+        if output_attr:
+            return str(output_attr)
+
+        return ""

--- a/tests/test_openai_client_streaming.py
+++ b/tests/test_openai_client_streaming.py
@@ -1,0 +1,161 @@
+"""Tests for OpenAIClient streaming helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+from src.models.openai_client import OpenAIClient, ResponseStreamObserver
+
+
+class RecordingObserver(ResponseStreamObserver):
+    """Test observer that records streaming callbacks."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.ended = False
+        self.deltas: List[Dict[str, int]] = []
+        self.totals: Dict[str, int] | None = None
+        self.errors: List[Any] = []
+        self.token_updates: List[Dict[str, int]] = []
+
+    def on_stream_start(self) -> None:  # pragma: no cover - simple flag
+        self.started = True
+
+    def on_text_delta(self, delta: str) -> None:  # pragma: no cover - ignored in tests
+        return
+
+    def on_usage_delta(self, delta: Dict[str, int]) -> None:
+        self.deltas.append(delta)
+
+    def on_usage_total(self, totals: Dict[str, int]) -> None:
+        self.totals = totals
+
+    def on_error(self, error: Any) -> None:  # pragma: no cover - defensive logging path
+        self.errors.append(error)
+
+    def on_stream_end(self) -> None:
+        self.ended = True
+
+    def on_token_progress(
+        self, total_tokens: int, delta_tokens: int, delta_chars: int
+    ) -> None:
+        self.token_updates.append(
+            {
+                "total": total_tokens,
+                "delta_tokens": delta_tokens,
+                "delta_chars": delta_chars,
+            }
+        )
+
+
+class FakeStream:
+    """Async stream stub returning predetermined events and final response."""
+
+    def __init__(self, events: List[Any], final_response: Any) -> None:
+        self._events = events
+        self._final_response = final_response
+
+    async def __aenter__(self) -> "FakeStream":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def __aiter__(self):
+        async def iterator():
+            for event in self._events:
+                yield event
+
+        return iterator()
+
+    async def get_final_response(self) -> Any:
+        return self._final_response
+
+
+class FakeResponses:
+    """Stub for AsyncOpenAI.responses that captures kwargs."""
+
+    def __init__(self, events: List[Any], final_response: Any) -> None:
+        self._events = events
+        self._final_response = final_response
+        self.last_kwargs: Dict[str, Any] | None = None
+
+    def stream(self, **kwargs: Any) -> FakeStream:
+        self.last_kwargs = kwargs
+        return FakeStream(self._events, self._final_response)
+
+
+class FakeAsyncOpenAI:
+    """Minimal AsyncOpenAI replacement for tests."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # events injected later by monkeypatching instance attribute
+        self.responses: FakeResponses | None = None
+
+
+@pytest.mark.asyncio
+async def test_streaming_requests_usage_and_emits_final_delta(monkeypatch) -> None:
+    usage = SimpleNamespace(input_tokens=11, output_tokens=7, total_tokens=18)
+    final_response = SimpleNamespace(
+        output_text="hello world",
+        usage=usage,
+        status="completed",
+        model="gpt-5",
+    )
+    delta_event = SimpleNamespace(type="response.output_text.delta", delta="hello")
+    events = [delta_event, SimpleNamespace(type="response.completed", response=final_response)]
+
+    fake_responses = FakeResponses(events=events, final_response=final_response)
+
+    def fake_make_client(*args: Any, **kwargs: Any) -> FakeAsyncOpenAI:
+        client = FakeAsyncOpenAI()
+        client.responses = fake_responses
+        return client
+
+    dummy_settings = SimpleNamespace(
+        openai_api_key="dummy",
+        openai_request_timeout_seconds=30,
+    )
+
+    monkeypatch.setattr("src.models.openai_client.AsyncOpenAI", fake_make_client)
+    monkeypatch.setattr("src.models.openai_client.get_settings", lambda: dummy_settings)
+    monkeypatch.setattr(
+        "src.models.openai_client.OpenAIClient._estimate_token_count",
+        lambda self, text, encoder: len(text),
+    )
+
+    client = OpenAIClient(model="gpt-5", api_key="test-key")
+
+    observer = RecordingObserver()
+    result = await client._call_responses_api_streaming(
+        final_messages=[{"role": "user", "content": "hi"}],
+        temperature=0.0,
+        max_tokens=None,
+        response_format=None,
+        reasoning_level=None,
+        system_prompt=None,
+        observer=observer,
+    )
+
+    assert fake_responses.last_kwargs is not None
+    assert "stream_options" not in fake_responses.last_kwargs.get("extra_body", {})
+
+    assert observer.deltas == [
+        {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+    ]
+    assert observer.totals == {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+    assert observer.started is True
+    assert observer.ended is True
+    assert not observer.errors
+    assert observer.token_updates == [
+        {"total": 5, "delta_tokens": 5, "delta_chars": 5}
+    ]
+
+    assert result["usage"] == {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    }


### PR DESCRIPTION
## Summary
- approximate live token counts from streaming text deltas and forward them to the CLI observer
- show "GPT-5 thinking…" until deltas arrive, then surface running token totals on the spinner
- add coverage harness exercising streaming observer, keeping final usage stats intact

## Testing
- pytest tests/test_openai_client_streaming.py
