### PR TITLE
Design: tool-call-mode V2

### DIFF
--- a/docs/design/tool-call-mode/CLI_SPEC.md
+++ b/docs/design/tool-call-mode/CLI_SPEC.md
@@ -494,7 +494,11 @@ Note: `screenshot_path` reflects the latest screenshot taken by the background t
 
 ### `haindy explore`
 
-Dispatch an open-ended exploration goal for background execution. The Situational Agent assesses the current screen, the Test Planner builds a mini-plan based on what is visible, and the Test Runner executes it. This cycle repeats until the goal is reached, the agent gets stuck, or the optional timeout fires. The coding agent polls `explore-status` for progress.
+Dispatch an open-ended exploration goal for background execution. The Awareness Agent owns a tight loop: it examines the latest screenshot, maintains a living TODO list of concrete next actions, calls the Action Agent directly to execute the next item, and reassesses after every action. The loop continues until the goal is reached, the agent gives up as stuck, human intervention is detected, or a limit is hit (`max_steps`, optional `timeout`). The coding agent polls `explore-status` for progress.
+
+Unlike `test`, `explore` does not build a fixed plan up front and does not use the Test Planner or Test Runner. The Awareness Agent is free to edit, reorder, skip, and add TODO items on every iteration as it learns more about the app. This makes exploration resilient to wrong assumptions: if a screen does not look like the agent expected, it simply updates the TODO instead of recording an assertion failure.
+
+On every iteration the Awareness Agent also watches for signs of human intervention or device loss -- the device was moved to a different app, the emulator shut down, a notification or consent dialog appeared, or the screen is otherwise in a state the agent did not cause. Notifications and dialogs are handled inline by adding TODO items to dismiss or respond to them. Unrecoverable interventions (device gone, foreign app in focus) end the loop with `aborted` so the coding agent can diagnose and decide whether to retry.
 
 Unlike `test`, `explore` does not require detailed step-by-step instructions. The coding agent provides a goal, and Haindy autonomously figures out how to navigate the device to achieve it. Any additional context the coding agent provides (current app state, relevant features, expected layout) improves the quality of exploration.
 
@@ -541,7 +545,7 @@ haindy explore "explore the settings menu and report what configuration options 
 }
 ```
 
-The dispatch takes an initial screenshot before starting the background task. This is the same screenshot the Situational Agent uses for its first screen assessment.
+The dispatch takes an initial screenshot before starting the background task. This is the same screenshot the Awareness Agent uses to build its initial TODO list.
 
 **When to use:** When the coding agent does not know the current device state, cannot write an unambiguous `test` scenario, or wants to discover what the app looks like and what options are available. Use `explore` for reconnaissance and `test` for verification.
 
@@ -568,6 +572,12 @@ If no explore has been dispatched in this session, returns `status: error` with 
   "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_005.png",
   "explore_status": "in_progress",
   "current_focus": "Examining the Settings main screen to find notification-related options.",
+  "todo": [
+    {"action": "Open the Profile tab from the bottom navigation bar", "status": "done"},
+    {"action": "Tap the gear icon on the Profile screen", "status": "done"},
+    {"action": "Tap the 'Notifications' row on the Settings main screen", "status": "in_progress"},
+    {"action": "Read the notification toggles and summarize the options available", "status": "pending"}
+  ],
   "observations": [
     "Home screen has a bottom navigation bar with Home, Search, Orders, Profile tabs.",
     "Profile tab contains a gear icon that leads to Settings.",
@@ -589,6 +599,12 @@ If no explore has been dispatched in this session, returns `status: error` with 
   "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_008.png",
   "explore_status": "goal_reached",
   "current_focus": null,
+  "todo": [
+    {"action": "Open the Profile tab from the bottom navigation bar", "status": "done"},
+    {"action": "Tap the gear icon on the Profile screen", "status": "done"},
+    {"action": "Tap the 'Notifications' row on the Settings main screen", "status": "done"},
+    {"action": "Read the notification toggles and summarize the options available", "status": "done"}
+  ],
   "observations": [
     "Home screen has a bottom navigation bar with Home, Search, Orders, Profile tabs.",
     "Profile tab contains a gear icon that leads to Settings.",
@@ -611,6 +627,13 @@ If no explore has been dispatched in this session, returns `status: error` with 
   "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_015.png",
   "explore_status": "stuck",
   "current_focus": null,
+  "todo": [
+    {"action": "Open the Profile tab", "status": "done"},
+    {"action": "Tap the gear icon on the Profile screen", "status": "done"},
+    {"action": "Look for a 'Notifications' row on the Settings main screen", "status": "done"},
+    {"action": "Check every Settings sub-menu for notification-related options", "status": "done"},
+    {"action": "Locate the notification settings screen", "status": "skipped"}
+  ],
   "observations": [
     "Settings contains: Account, Display, Language, About.",
     "Account sub-menu has: Email, Password, Delete Account.",
@@ -622,16 +645,47 @@ If no explore has been dispatched in this session, returns `status: error` with 
 }
 ```
 
+**Stdout (aborted -- human intervention or device loss):**
+
+```json
+{
+  "session_id": "a3f9c2d1-...",
+  "command": "explore-status",
+  "status": "success",
+  "response": "Exploration aborted. The device is no longer showing the target app. The screen is now on the Android home launcher, which Haindy did not cause. Something external (a user interaction, another app taking focus, or the emulator restarting) moved the device out of the exploration context.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_011.png",
+  "explore_status": "aborted",
+  "current_focus": null,
+  "todo": [
+    {"action": "Open the Profile tab", "status": "done"},
+    {"action": "Tap the gear icon on the Profile screen", "status": "done"},
+    {"action": "Tap the 'Notifications' row on the Settings main screen", "status": "in_progress"},
+    {"action": "Read the notification toggles and summarize the options available", "status": "pending"}
+  ],
+  "observations": [
+    "Home screen has a bottom navigation bar with Home, Search, Orders, Profile tabs.",
+    "Profile tab contains a gear icon that leads to Settings.",
+    "Settings main screen shows: Account, Notifications, Privacy, About.",
+    "Device unexpectedly returned to Android launcher after the last action."
+  ],
+  "elapsed_time_seconds": 22,
+  "meta": {"exit_reason": "aborted", "duration_ms": 4, "actions_taken": 11}
+}
+```
+
 **Extended fields for `explore-status`:**
 
 | Field | Type | Description |
 |---|---|---|
-| `explore_status` | string | `in_progress`, `goal_reached`, `stuck`, `timeout`, `max_steps_reached`, `error`. |
-| `current_focus` | string or null | What Haindy is currently trying to do. `null` when explore is finished. |
-| `observations` | list of strings | Accumulating list of things Haindy has observed during exploration. Each entry is a factual observation about the app state or navigation structure. |
+| `explore_status` | string | `in_progress`, `goal_reached`, `stuck`, `aborted`, `timeout`, `max_steps_reached`, `error`. |
+| `current_focus` | string or null | What the Awareness Agent is currently trying to do. `null` when explore is finished. |
+| `todo` | list of objects | The Awareness Agent's living TODO list. Each entry is `{"action": string, "status": "pending" \| "in_progress" \| "done" \| "skipped"}`. The list is mutable across iterations -- items may be added, reordered, or skipped as the agent learns more. Completed, skipped, and pending items are all shown so the coding agent can reconstruct the trajectory. |
+| `observations` | list of strings | Accumulating list of things the Awareness Agent has observed during exploration. Each entry is a factual observation about the app state or navigation structure. |
 | `elapsed_time_seconds` | integer | Wall-clock time since explore was dispatched. |
 
-Note: `explore_status` avoids the terms "passed" and "failed" because exploration is not a pass/fail assertion. It either reaches the goal (`goal_reached`), determines it cannot proceed (`stuck`), or is bounded by limits (`timeout`, `max_steps_reached`).
+Note: `explore_status` avoids the terms "passed" and "failed" because exploration is not a pass/fail assertion. It either reaches the goal (`goal_reached`), determines it cannot proceed on its own (`stuck`), is interrupted by something outside Haindy's control (`aborted`), or is bounded by limits (`timeout`, `max_steps_reached`).
+
+`aborted` specifically means the Awareness Agent detected that the device is no longer in a state Haindy produced -- e.g. the target app lost focus, the emulator restarted, or a user touched the device. It is distinct from `stuck`, which means Haindy tried and could not find a way forward on its own.
 
 Note: `screenshot_path` reflects the latest screenshot taken by the background task. The coding agent should take its own screenshots via `screenshot` at its own timing if it needs to verify device state independently.
 
@@ -714,7 +768,7 @@ haindy session prune --older-than <days>
 | Sync commands (`act`, `screenshot`, `session *`) | `completed`, `element_not_found`, `command_timeout`, `agent_error`, `device_error`, `session_busy` |
 | Async dispatch (`test`, `explore`) | `dispatched`, `session_busy` |
 | `test-status` (terminal) | `completed`, `assertion_failed`, `max_steps_reached`, `timeout`, `agent_error`, `device_error` |
-| `explore-status` (terminal) | `goal_reached`, `stuck`, `goal_unreachable`, `max_steps_reached`, `timeout`, `agent_error`, `device_error` |
+| `explore-status` (terminal) | `goal_reached`, `stuck`, `aborted`, `max_steps_reached`, `timeout`, `agent_error`, `device_error` |
 
 ### Extended fields for `test-status`
 
@@ -734,8 +788,11 @@ haindy session prune --older-than <days>
 
 ```json
 {
-  "explore_status": "in_progress | goal_reached | stuck | timeout | max_steps_reached | error",
+  "explore_status": "in_progress | goal_reached | stuck | aborted | timeout | max_steps_reached | error",
   "current_focus": "string | null",
+  "todo": [
+    {"action": "string", "status": "pending | in_progress | done | skipped"}
+  ],
   "observations": ["string"],
   "elapsed_time_seconds": "integer"
 }

--- a/docs/design/tool-call-mode/CLI_SPEC.md
+++ b/docs/design/tool-call-mode/CLI_SPEC.md
@@ -6,9 +6,11 @@
 haindy <subcommand> [options]
 ```
 
-All tool call mode subcommands are grouped under two top-level subcommands:
+All tool call mode subcommands are grouped under:
 - `session` - manage sessions and session variables
-- Direct action subcommands: `act`, `test`
+- Synchronous action subcommands: `act`, `screenshot`
+- Async dispatch subcommands: `test`, `explore`
+- Status poll subcommands: `test-status`, `explore-status`
 
 Commands that operate on an existing session require an explicit `--session <id>` flag.
 `haindy session new` does not take `--session` because it creates the session.
@@ -34,18 +36,20 @@ Start a new session. Spawns the daemon process, initializes the device connectio
 For desktop sessions, tool call mode does not own project startup. The coding agent is responsible for making sure the target site or native desktop app is already running before or around session start; Haindy owns the UI interaction after that point.
 
 ```
-haindy session new [--android | --desktop] [options]
+haindy session new [--android | --ios | --desktop] [options]
 ```
 
 **Flags:**
 
 | Flag | Default | Description |
 |---|---|---|
-| `--android` | | Use Android ADB backend. Mutually exclusive with `--desktop`. |
+| `--android` | | Use Android ADB backend. Mutually exclusive with `--ios` and `--desktop`. |
 | `--android-serial <serial>` | | Target a specific Android device or emulator by ADB serial (e.g. `emulator-5554`). Optional; uses the only connected device if omitted. |
 | `--android-app <package>` | | Android package name to launch on session start (e.g. `com.example.app`). Optional. |
-| `--desktop` | | Use the desktop backend (computer use: OS screen capture + AI-driven input). Mutually exclusive with `--android`. Default if neither specified and no env config. |
-| `--url <url>` | | URL to open on session start (desktop only). Optional. |
+| `--ios` | | Use iOS idb backend. Mutually exclusive with `--android` and `--desktop`. |
+| `--ios-udid <udid>` | | Target a specific iOS device or simulator by UDID. Optional; uses the only connected device if omitted. |
+| `--ios-app <bundle_id>` | | iOS bundle identifier to launch on session start (e.g. `com.example.app`). Optional. |
+| `--desktop` | | Use the desktop backend (computer use: OS screen capture + AI-driven input). Mutually exclusive with `--android` and `--ios`. Default if neither specified and no env config. |
 | `--idle-timeout <seconds>` | 1800 | Kill daemon after this many seconds without a command. |
 
 **Stdout on success:**
@@ -70,11 +74,12 @@ haindy session status --session <SESSION_ID>
 haindy test "open the app and verify the dashboard appears" --session <SESSION_ID>
 ```
 
-**Desktop startup guidance:**
+**Device startup guidance:**
 
 - Web project: make sure the site or dev server is already running before `haindy session new --desktop`. If a browser is not open yet, instruct Haindy to open one and navigate to the URL like a human would. Prefer a maximized browser window.
 - Native desktop app: make sure the app is already running before `haindy session new --desktop`. If needed, instruct Haindy to bring it to the foreground using normal desktop UI actions. Prefer a maximized app window when possible.
-- Android mobile: start the session against a device or emulator that ADB can reach, and pass `--android-serial` / `--android-app` when needed.
+- Android: start the session against a device or emulator that ADB can reach, and pass `--android-serial` / `--android-app` when needed.
+- iOS: start the session against a device or simulator that idb can reach, and pass `--ios-udid` / `--ios-app` when needed.
 - Desktop sessions may downshift resolution for speed and token savings, so maximizing the target browser or app window helps keep screenshots focused on the app instead of surrounding desktop noise.
 
 ---
@@ -262,9 +267,11 @@ haindy session vars --session <id>
 
 ---
 
-## Action Subcommands
+## Synchronous Action Subcommands
 
-All action subcommands share this behavior:
+These commands block until the operation completes and return the result directly.
+
+Shared behavior:
 - Require an explicit `--session <id>`.
 - Support `--timeout <seconds>`. If the timeout is reached, the command ends with `meta.exit_reason: command_timeout`.
 - Return a single JSON object on stdout (the standard envelope, see OVERVIEW.md).
@@ -330,9 +337,23 @@ haindy act "press the back button" --session <SESSION_ID>
 
 ---
 
+## Async Dispatch Subcommands
+
+These commands dispatch work to the daemon's background task runner and return immediately. The coding agent polls for progress using the corresponding status command (`test-status` or `explore-status`).
+
+Shared behavior:
+- Require an explicit `--session <id>`.
+- Return immediately with `meta.exit_reason: dispatched` and exit 0.
+- The daemon runs one background task at a time per session. If a background task is already running, the dispatch returns `status: error` with `meta.exit_reason: session_busy`.
+- The `--timeout` flag sets the wall-clock budget for the background task, not for the dispatch itself.
+
+---
+
 ### `haindy test`
 
-Run a full test scenario. The Test Planner generates a structured plan from the description, then the Test Runner executes each step and validates outcomes. Maps to Test Planner + Test Runner.
+Dispatch a test scenario for background execution. The Test Planner generates a structured plan from the description, then the Test Runner executes each step and validates outcomes. The coding agent polls `test-status` for progress and results.
+
+The scenario description must be detailed and unambiguous. Vague or high-level descriptions produce unreliable plans. The coding agent should provide explicit steps, specific UI elements to interact with, concrete values to enter, and clear expected outcomes. If the coding agent does not have enough detail to write an unambiguous scenario, it should use `explore` or `session status` first to understand the current state.
 
 ```
 haindy test "<scenario>" --session <id> [--max-steps <n>] [--timeout <seconds>]
@@ -340,74 +361,308 @@ haindy test "<scenario>" --session <id> [--max-steps <n>] [--timeout <seconds>]
 
 **Argument:**
 
-`<scenario>` - A natural language description of a complete test scenario. May be multi-sentence. Should describe the goal, the actions, and the expected end state.
+`<scenario>` - A detailed, unambiguous description of the test scenario. Must include: what actions to perform, in what order, what values to use, and what the expected outcome is. May be multi-sentence.
 
 **Flags:**
 
 | Flag | Default | Description |
 |---|---|---|
-| `--max-steps <n>` | 20 | Maximum number of steps the Test Runner may execute. |
-| `--timeout <seconds>` | 300 | Maximum wall-clock time for the command before Haindy stops execution and returns `meta.exit_reason: command_timeout`. |
+| `--max-steps <n>` | 20 | Maximum number of steps the Test Runner may execute before returning `max_steps_reached`. |
+| `--timeout <seconds>` | 300 | Maximum wall-clock time for the background task. When reached, the test stops with `timeout`. |
 
 **Examples:**
 
 ```bash
-haindy test "sign in with user@example.com and password hunter2, navigate to Settings, change the display name to 'Bob', save, and verify the new name appears in the profile header" --session <SESSION_ID>
+# Good: detailed, unambiguous, explicit steps and expected outcomes
+haindy test "Step 1: Tap the email field and type 'alice@example.com'. Step 2: Tap the password field and type '{{PASSWORD}}'. Step 3: Tap the 'Sign In' button. Step 4: Verify the dashboard screen appears with the text 'Welcome, Alice' in the header." --session <SESSION_ID>
 
-haindy test "attempt to sign in with an incorrect password three times and verify that the account lockout screen appears after the third attempt" --session <SESSION_ID>
+# Good: clear precondition, specific action, explicit assertion
+haindy test "Starting from the Settings screen, tap 'Change Password', enter 'oldpass123' in the current password field and 'newpass456' in the new password field, tap 'Save', and verify a success toast appears saying 'Password updated'." --session <SESSION_ID>
+
+# Bad: vague, no specific steps or expected outcomes
+# haindy test "test the login flow" --session <SESSION_ID>
 ```
 
-**Stdout on success:**
+**Stdout (dispatch acknowledgement):**
 
 ```json
 {
   "session_id": "a3f9c2d1-...",
   "command": "test",
   "status": "success",
-  "response": "Test passed in 6 steps. Successfully signed in, navigated to Settings, updated the display name to 'Bob', saved changes. The profile header confirmed 'Bob' as the display name.",
-  "steps_total": 6,
-  "steps_passed": 6,
-  "steps_failed": 0,
-  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_012.png",
-  "meta": {"exit_reason": "completed", "duration_ms": 18420, "actions_taken": 14}
+  "response": "Test dispatched. Poll test-status for progress.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_005.png",
+  "meta": {"exit_reason": "dispatched", "duration_ms": 52, "actions_taken": 1}
 }
 ```
 
-**Stdout on failure:**
+The dispatch takes an initial screenshot before starting the background task. This captures the device state at the moment the test was accepted and provides visual context in the dispatch response.
+
+**When to use:** When the coding agent has a well-defined scenario with explicit steps and expected outcomes. The scenario should be detailed enough that a human tester could follow it without asking questions. For open-ended goals or unknown screen states, use `explore` instead.
+
+---
+
+### `haindy test-status`
+
+Poll the progress of a running or completed `test` background task.
+
+```
+haindy test-status --session <id>
+```
+
+If no test has been dispatched in this session, returns `status: error` with `meta.exit_reason: completed` and a response explaining no test is active.
+
+**Stdout (test in progress):**
 
 ```json
 {
   "session_id": "a3f9c2d1-...",
-  "command": "test",
-  "status": "failure",
-  "response": "Test failed at step 4 of 6. Steps 1-3 (sign in, navigate to Settings, enter new name) passed. Step 4 failed: tapping 'Save' showed a validation error 'Display name must be at least 3 characters'. The name 'Bob' was rejected.",
+  "command": "test-status",
+  "status": "success",
+  "response": "Test in progress. Completed step 3 of 6: typed 'alice@example.com' into the email field. Currently executing step 4: tap the 'Sign In' button.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_008.png",
+  "test_status": "in_progress",
+  "current_step": "Step 4: Tap the 'Sign In' button and wait for the dashboard to load.",
   "steps_total": 6,
-  "steps_passed": 3,
-  "steps_failed": 1,
-  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_009.png",
-  "meta": {"exit_reason": "assertion_failed", "duration_ms": 11230, "actions_taken": 9}
+  "steps_completed": 3,
+  "steps_failed": 0,
+  "issues_found": {},
+  "elapsed_time_seconds": 14,
+  "meta": {"exit_reason": "completed", "duration_ms": 5, "actions_taken": 7}
 }
 ```
 
-Note: `test` adds `steps_total`, `steps_passed`, and `steps_failed` fields to the standard envelope.
+**Stdout (test passed):**
 
-**When to use:** For anything that requires outcome validation - single interactions with expected results, multi-step journeys, regression checks, and open-ended scenarios. This is the primary command in tool call mode.
+```json
+{
+  "session_id": "a3f9c2d1-...",
+  "command": "test-status",
+  "status": "success",
+  "response": "Test passed. All 6 steps completed successfully. The dashboard shows 'Welcome, Alice' as expected.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_012.png",
+  "test_status": "passed",
+  "current_step": null,
+  "steps_total": 6,
+  "steps_completed": 6,
+  "steps_failed": 0,
+  "issues_found": {},
+  "elapsed_time_seconds": 42,
+  "meta": {"exit_reason": "completed", "duration_ms": 4, "actions_taken": 14}
+}
+```
+
+**Stdout (test failed):**
+
+```json
+{
+  "session_id": "a3f9c2d1-...",
+  "command": "test-status",
+  "status": "success",
+  "response": "Test failed at step 4 of 6. Steps 1-3 passed. Step 4 failed: after tapping 'Sign In', the screen showed 'Invalid credentials' instead of the dashboard.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_009.png",
+  "test_status": "failed",
+  "current_step": null,
+  "steps_total": 6,
+  "steps_completed": 3,
+  "steps_failed": 1,
+  "issues_found": {
+    "step_4": "Expected dashboard with 'Welcome, Alice'. Observed: error message 'Invalid credentials' on the sign-in screen."
+  },
+  "elapsed_time_seconds": 31,
+  "meta": {"exit_reason": "assertion_failed", "duration_ms": 3, "actions_taken": 9}
+}
+```
+
+**Extended fields for `test-status`:**
+
+| Field | Type | Description |
+|---|---|---|
+| `test_status` | string | `in_progress`, `passed`, `failed`, `error`, `timeout`, `max_steps_reached`. |
+| `current_step` | string or null | Description of the step currently being executed. `null` when test is finished. |
+| `steps_total` | integer | Total steps in the planned test. |
+| `steps_completed` | integer | Steps that have passed so far. |
+| `steps_failed` | integer | Steps that have failed. |
+| `issues_found` | object | Map of step identifiers to failure descriptions. Empty when no failures. |
+| `elapsed_time_seconds` | integer | Wall-clock time since the test was dispatched. |
+
+Note: `meta.exit_reason` on a `test-status` poll reflects the background task state, not the poll itself. While in progress, it is `completed` (the poll succeeded). When the test finishes, it reflects the test outcome (`completed`, `assertion_failed`, `max_steps_reached`, `timeout`, `agent_error`, `device_error`).
+
+Note: `screenshot_path` reflects the latest screenshot taken by the background task. The coding agent should take its own screenshots via `screenshot` at its own timing if it needs to verify device state independently, because Haindy's screenshots may not capture the exact moment the agent needs.
 
 ---
 
-### `haindy explore` (v2 - not available in v1)
+### `haindy explore`
 
-> **Not implemented in v1.** Use `test` for open-ended goals in the meantime - it accepts natural language scenarios and plans them automatically.
+Dispatch an open-ended exploration goal for background execution. The Situational Agent assesses the current screen, the Test Planner builds a mini-plan based on what is visible, and the Test Runner executes it. This cycle repeats until the goal is reached, the agent gets stuck, or the optional timeout fires. The coding agent polls `explore-status` for progress.
 
-Blocked on: extending the Situational Agent from text-context gating to live-screen assessment (screenshot in, device state description out).
+Unlike `test`, `explore` does not require detailed step-by-step instructions. The coding agent provides a goal, and Haindy autonomously figures out how to navigate the device to achieve it. Any additional context the coding agent provides (current app state, relevant features, expected layout) improves the quality of exploration.
 
-**Planned interface:**
+The goal should be achievable by looking at the screens and interacting with the app. It should not require knowledge that is not discoverable from the UI itself.
 
 ```
 haindy explore "<goal>" --session <id> [--max-steps <n>] [--timeout <seconds>]
 ```
 
-**Intended use case:** When the coding agent does not know the current device state and cannot write a `test` scenario without first knowing what screen it is on. `explore` will take a screenshot, assess the situation, build a mini-plan, and execute it autonomously.
+**Argument:**
+
+`<goal>` - A natural language description of what to explore or achieve. Should be focused and realistic -- achievable by navigating and interacting with visible UI elements.
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--max-steps <n>` | 50 | Maximum number of steps before returning `max_steps_reached`. |
+| `--timeout <seconds>` | none | Optional wall-clock budget for the background task. If omitted, explore runs until the goal is reached, the agent gets stuck, or max-steps is hit. |
+
+**Examples:**
+
+```bash
+# Focused, achievable goal
+haindy explore "find and open the notification settings screen" --session <SESSION_ID>
+
+# Goal with helpful context
+haindy explore "navigate to the order history and find the most recent order. The app should have a bottom navigation bar with an 'Orders' tab." --session <SESSION_ID>
+
+# Open-ended discovery
+haindy explore "explore the settings menu and report what configuration options are available" --session <SESSION_ID>
+```
+
+**Stdout (dispatch acknowledgement):**
+
+```json
+{
+  "session_id": "a3f9c2d1-...",
+  "command": "explore",
+  "status": "success",
+  "response": "Explore dispatched. Poll explore-status for progress.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_003.png",
+  "meta": {"exit_reason": "dispatched", "duration_ms": 48, "actions_taken": 1}
+}
+```
+
+The dispatch takes an initial screenshot before starting the background task. This is the same screenshot the Situational Agent uses for its first screen assessment.
+
+**When to use:** When the coding agent does not know the current device state, cannot write an unambiguous `test` scenario, or wants to discover what the app looks like and what options are available. Use `explore` for reconnaissance and `test` for verification.
+
+---
+
+### `haindy explore-status`
+
+Poll the progress of a running or completed `explore` background task.
+
+```
+haindy explore-status --session <id>
+```
+
+If no explore has been dispatched in this session, returns `status: error` with a response explaining no explore is active.
+
+**Stdout (explore in progress):**
+
+```json
+{
+  "session_id": "a3f9c2d1-...",
+  "command": "explore-status",
+  "status": "success",
+  "response": "Exploring. Currently looking at the Settings main screen after navigating from the home screen via the gear icon.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_005.png",
+  "explore_status": "in_progress",
+  "current_focus": "Examining the Settings main screen to find notification-related options.",
+  "observations": [
+    "Home screen has a bottom navigation bar with Home, Search, Orders, Profile tabs.",
+    "Profile tab contains a gear icon that leads to Settings.",
+    "Settings main screen shows: Account, Notifications, Privacy, About."
+  ],
+  "elapsed_time_seconds": 18,
+  "meta": {"exit_reason": "completed", "duration_ms": 4, "actions_taken": 5}
+}
+```
+
+**Stdout (goal reached):**
+
+```json
+{
+  "session_id": "a3f9c2d1-...",
+  "command": "explore-status",
+  "status": "success",
+  "response": "Goal reached. Found and opened the notification settings screen. It contains toggles for push notifications, email notifications, and SMS alerts.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_008.png",
+  "explore_status": "goal_reached",
+  "current_focus": null,
+  "observations": [
+    "Home screen has a bottom navigation bar with Home, Search, Orders, Profile tabs.",
+    "Profile tab contains a gear icon that leads to Settings.",
+    "Settings main screen shows: Account, Notifications, Privacy, About.",
+    "Notification settings screen has toggles: Push Notifications (on), Email Notifications (on), SMS Alerts (off)."
+  ],
+  "elapsed_time_seconds": 27,
+  "meta": {"exit_reason": "goal_reached", "duration_ms": 3, "actions_taken": 8}
+}
+```
+
+**Stdout (stuck):**
+
+```json
+{
+  "session_id": "a3f9c2d1-...",
+  "command": "explore-status",
+  "status": "success",
+  "response": "Exploration ended. Could not find a way to reach the notification settings. After navigating to Settings, all sub-menus were explored but none contained notification options. The app may not have a dedicated notification settings screen.",
+  "screenshot_path": "/home/user/.haindy/sessions/a3f9c2d1-.../screenshots/step_015.png",
+  "explore_status": "stuck",
+  "current_focus": null,
+  "observations": [
+    "Settings contains: Account, Display, Language, About.",
+    "Account sub-menu has: Email, Password, Delete Account.",
+    "Display sub-menu has: Theme, Font Size.",
+    "No notification-related options found in any settings sub-menu."
+  ],
+  "elapsed_time_seconds": 45,
+  "meta": {"exit_reason": "stuck", "duration_ms": 4, "actions_taken": 15}
+}
+```
+
+**Extended fields for `explore-status`:**
+
+| Field | Type | Description |
+|---|---|---|
+| `explore_status` | string | `in_progress`, `goal_reached`, `stuck`, `timeout`, `max_steps_reached`, `error`. |
+| `current_focus` | string or null | What Haindy is currently trying to do. `null` when explore is finished. |
+| `observations` | list of strings | Accumulating list of things Haindy has observed during exploration. Each entry is a factual observation about the app state or navigation structure. |
+| `elapsed_time_seconds` | integer | Wall-clock time since explore was dispatched. |
+
+Note: `explore_status` avoids the terms "passed" and "failed" because exploration is not a pass/fail assertion. It either reaches the goal (`goal_reached`), determines it cannot proceed (`stuck`), or is bounded by limits (`timeout`, `max_steps_reached`).
+
+Note: `screenshot_path` reflects the latest screenshot taken by the background task. The coding agent should take its own screenshots via `screenshot` at its own timing if it needs to verify device state independently.
+
+---
+
+### `haindy session prune`
+
+Delete session directories older than a given age. Does not affect live sessions with running daemons.
+
+```
+haindy session prune --older-than <days>
+```
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--older-than <days>` | Required. Delete session directories whose `created_at` is older than this many days. |
+
+**Stdout:**
+
+```json
+{
+  "session_id": null,
+  "command": "session",
+  "status": "success",
+  "response": "Pruned 3 session directories older than 7 days. 2 active sessions were skipped.",
+  "screenshot_path": null,
+  "meta": {"exit_reason": "completed", "duration_ms": 45, "actions_taken": 0}
+}
+```
 
 ---
 
@@ -416,7 +671,7 @@ haindy explore "<goal>" --session <id> [--max-steps <n>] [--timeout <seconds>]
 | Variable | Description |
 |---|---|
 | `HAINDY_HOME` | Override the base directory (default: `~/.haindy`). Useful in CI. |
-| `HAINDY_BACKEND` | Default backend for new sessions: `desktop` or `android`. Overridden by `--android`/`--desktop`. |
+| `HAINDY_BACKEND` | Default backend for new sessions: `desktop`, `android`, or `ios`. Overridden by `--android`/`--ios`/`--desktop`. |
 
 ---
 
@@ -433,32 +688,56 @@ haindy explore "<goal>" --session <id> [--max-steps <n>] [--timeout <seconds>]
 
 ## Full JSON Contract Reference
 
-### Standard Envelope (all action subcommands)
+### Standard Envelope (all commands)
 
 ```json
 {
   "session_id": "string (UUID) | null",
-  "command": "act | test | session",
+  "command": "act | screenshot | test | test-status | explore | explore-status | session",
   "status": "success | failure | error",
   "response": "string (natural language, always present)",
   "screenshot_path": "string (absolute path) | null",
   "meta": {
-    "exit_reason": "completed | assertion_failed | max_steps_reached | max_actions_reached | element_not_found | command_timeout | agent_error | device_error | session_busy",
+    "exit_reason": "string (see exit_reason values below)",
     "duration_ms": "integer",
     "actions_taken": "integer"
   }
 }
 ```
 
-`actions_taken` counts device operations performed to satisfy the command. A fresh screenshot taken for `session status` counts as 1. Session startup and shutdown bookkeeping does not.
+`actions_taken` counts device operations performed. For sync commands, this is the count from the command itself. For async dispatch, this is 1 (the initial screenshot). For status polls, this is the background task's running total. A fresh screenshot taken for `session status` counts as 1. Session startup and shutdown bookkeeping does not.
 
-### Extended fields for `test`
+### exit_reason values
+
+| Context | Values |
+|---|---|
+| Sync commands (`act`, `screenshot`, `session *`) | `completed`, `element_not_found`, `command_timeout`, `agent_error`, `device_error`, `session_busy` |
+| Async dispatch (`test`, `explore`) | `dispatched`, `session_busy` |
+| `test-status` (terminal) | `completed`, `assertion_failed`, `max_steps_reached`, `timeout`, `agent_error`, `device_error` |
+| `explore-status` (terminal) | `goal_reached`, `stuck`, `goal_unreachable`, `max_steps_reached`, `timeout`, `agent_error`, `device_error` |
+
+### Extended fields for `test-status`
 
 ```json
 {
+  "test_status": "in_progress | passed | failed | error | timeout | max_steps_reached",
+  "current_step": "string | null",
   "steps_total": "integer",
-  "steps_passed": "integer",
-  "steps_failed": "integer"
+  "steps_completed": "integer",
+  "steps_failed": "integer",
+  "issues_found": {"step_N": "string"},
+  "elapsed_time_seconds": "integer"
+}
+```
+
+### Extended fields for `explore-status`
+
+```json
+{
+  "explore_status": "in_progress | goal_reached | stuck | timeout | max_steps_reached | error",
+  "current_focus": "string | null",
+  "observations": ["string"],
+  "elapsed_time_seconds": "integer"
 }
 ```
 
@@ -469,7 +748,7 @@ haindy explore "<goal>" --session <id> [--max-steps <n>] [--timeout <seconds>]
   "sessions": [
     {
       "session_id": "string",
-      "backend": "desktop | android",
+      "backend": "desktop | android | ios",
       "created_at": "ISO 8601 datetime",
       "steps_executed": "integer",
       "idle_seconds": "integer"

--- a/docs/design/tool-call-mode/OVERVIEW.md
+++ b/docs/design/tool-call-mode/OVERVIEW.md
@@ -62,7 +62,7 @@ flowchart TD
         AA[Action Agent]
         TR[Test Runner]
         TP[Test Planner]
-        SIT[Situational Agent]
+        AWA[Awareness Agent]
     end
 
     subgraph DEVICE ["Device"]
@@ -79,11 +79,11 @@ flowchart TD
     DISP -->|test| BG
     DISP -->|explore| BG
     BG -->|test| TP
-    BG -->|explore| SIT
+    BG -->|explore| AWA
 
-    SIT --> TP
     TP --> TR
     TR --> AA
+    AWA --> AA
     AA --> DEVICE
 
     DISP -->|JSON response| CLI
@@ -104,7 +104,7 @@ flowchart TD
 
 **Test Planner**: Accepts a detailed scenario description with explicit steps and expected outcomes, and produces a structured sequence of steps. Used by the `test` command. Requires unambiguous, detailed input from the coding agent.
 
-**Situational Agent**: Assesses live device state from a screenshot to determine the current screen context and decide how to proceed. Used by the `explore` command to handle unknown or changing screen states during open-ended exploration.
+**Awareness Agent**: Drives the `explore` loop. On each iteration it examines the latest screenshot, maintains a living TODO list of concrete actions, detects human intervention or device loss, and decides whether to continue, stop at the goal, give up as stuck, or abort. The Awareness Agent calls the Action Agent directly with the next TODO item -- there is no Test Planner or Test Runner in the explore path. This keeps the loop tight (one model call per iteration for perception + decision) and lets the agent freely backtrack by editing the TODO instead of treating an initial plan as gospel. The standard-mode Situational Agent (text-based context gating for the batch pipeline) is unrelated and unused in tool call mode.
 
 ---
 
@@ -113,9 +113,9 @@ flowchart TD
 Each command maps to a different level of the agent stack:
 
 ```
-explore       ──►  Situational Agent + Test Planner + Test Runner + Action Agent  (async)
-test          ──►  Test Planner + Test Runner + Action Agent                      (async)
-act           ──►  Action Agent only                                              (sync)
+explore       ──►  Awareness Agent + Action Agent                   (async)
+test          ──►  Test Planner + Test Runner + Action Agent        (async)
+act           ──►  Action Agent only                                (sync)
 ```
 
 The coding agent should pick the right level of abstraction:
@@ -220,7 +220,9 @@ Exit codes mirror status: 0 for `success`, 1 for `failure` or `error`.
 | **IPC** | Inter-process communication between CLI client and daemon, over a Unix domain socket. |
 | **act** | A single direct device interaction with no outcome validation. Synchronous. |
 | **test** | A detailed, unambiguous scenario dispatched to the Test Planner and Test Runner. Asynchronous -- returns immediately; poll `test-status` for progress and results. |
-| **explore** | An open-ended goal handled by the Situational Agent + Test Planner + Test Runner. Asynchronous -- returns immediately; poll `explore-status` for progress and observations. |
+| **explore** | An open-ended goal handled by the Awareness Agent driving the Action Agent directly in a tight loop. Asynchronous -- returns immediately; poll `explore-status` for progress, TODO, and observations. |
 | **test-status** | Polls the progress of a running or completed `test` background task. |
 | **explore-status** | Polls the progress of a running or completed `explore` background task. |
-| **exit_reason** | The `meta` field explaining why a command terminated. Sync commands: `completed`, `element_not_found`, `command_timeout`, `agent_error`, `device_error`, `session_busy`. Async dispatch: `dispatched`. Background task results: `completed`, `assertion_failed`, `max_steps_reached`, `stuck`, `goal_reached`, `goal_unreachable`, `timeout`, `agent_error`, `device_error`. |
+| **Awareness Agent** | The agent that owns the `explore` loop. Maintains a living TODO list, assesses each screenshot, detects human intervention, and calls the Action Agent directly. Only used in tool call mode. |
+| **TODO list** | A mutable list of concrete actions the Awareness Agent plans to take next. Items have a status (`pending`, `in_progress`, `done`, `skipped`) and the Awareness Agent may add, reorder, or skip items on every iteration as it learns more about the app. Exposed via the `explore-status` response. |
+| **exit_reason** | The `meta` field explaining why a command terminated. Sync commands: `completed`, `element_not_found`, `command_timeout`, `agent_error`, `device_error`, `session_busy`. Async dispatch: `dispatched`. Background task results: `completed`, `assertion_failed`, `max_steps_reached`, `stuck`, `goal_reached`, `aborted`, `timeout`, `agent_error`, `device_error`. |

--- a/docs/design/tool-call-mode/OVERVIEW.md
+++ b/docs/design/tool-call-mode/OVERVIEW.md
@@ -23,7 +23,8 @@ The goal of tool call mode is to expose Haindy as a first-class tool that a codi
 - **CLI over MCP/API**: A well-designed CLI paired with a skill requires less context and has better adoption than an MCP server or custom API. Coding agents are trained to use CLIs and can learn new ones via a skill loaded in-context.
 - **Session-based**: A persistent session daemon keeps the device alive between calls, avoiding expensive re-initialization on every command.
 - **Independent daemon launch**: `session new` returns only after an independently launched daemon is ready on its Unix socket, so later commands are not coupled to the parent CLI process lifetime.
-- **Layered abstraction**: Commands are tiered from direct device actions up to full test plans. The coding agent picks the right level of abstraction for its needs.
+- **Layered abstraction**: Commands are tiered from direct device actions up to open-ended exploration. The coding agent picks the right level of abstraction for its needs.
+- **Async long-running commands**: `test` and `explore` return immediately after dispatch and run in the background. The coding agent polls for status at its own pace, keeping control of its tool-use loop and token budget.
 - **Stable JSON contract**: Every command returns the same JSON envelope. The `status` field is machine-readable. The `response` field is natural language that the coding agent can pass directly to the user or reason about.
 - **Screenshot on every response**: Agents need visual grounding. Every response includes a path to the latest screenshot.
 
@@ -45,26 +46,28 @@ flowchart TD
     CA["Coding Agent\n(Codex / Claude Code / other)"]
 
     subgraph CLI ["haindy CLI (tool call mode)"]
-        SC[session new/close/list/set/vars]
-        ACT[act]
-        TEST[test]
-        EXP[explore - v2]
+        SC[session new/close/list/set/vars/prune]
+        ACT[act / screenshot]
+        TEST[test / test-status]
+        EXP[explore / explore-status]
     end
 
     subgraph DAEMON ["Session Daemon (per session)"]
         SOCK[Unix Socket Listener]
         DISP[Command Dispatcher]
+        BG[Background Task Runner]
     end
 
     subgraph AGENTS ["Haindy Agent Layer"]
         AA[Action Agent]
         TR[Test Runner]
         TP[Test Planner]
-        SIT[Situational Agent - v2]
+        SIT[Situational Agent]
     end
 
     subgraph DEVICE ["Device"]
         ADB[Android via ADB]
+        IDB[iOS via idb]
         DT[Desktop via CU]
     end
 
@@ -73,12 +76,15 @@ flowchart TD
     SOCK --> DISP
 
     DISP -->|act| AA
-    DISP -->|test| TP
-    DISP -->|test| TR
+    DISP -->|test| BG
+    DISP -->|explore| BG
+    BG -->|test| TP
+    BG -->|explore| SIT
 
-    AA --> DEVICE
-    TR --> AA
+    SIT --> TP
     TP --> TR
+    TR --> AA
+    AA --> DEVICE
 
     DISP -->|JSON response| CLI
     CLI -->|stdout JSON| CA
@@ -88,15 +94,17 @@ flowchart TD
 
 **CLI client** (`haindy <subcommand>`): Thin wrapper. Locates the session daemon socket from the explicit session ID provided on the command, sends the command over IPC, waits for the JSON response, prints to stdout, exits with code 0 (success) or 1 (failure/error).
 
-**Session Daemon**: A long-running Python process launched by `haindy session new` through a dedicated daemonization helper. Owns the device connection for the lifetime of the session. Listens on a Unix socket at `~/.haindy/sessions/<id>/daemon.sock`. Dispatches incoming commands to the appropriate agent and returns JSON.
+**Session Daemon**: A long-running Python process launched by `haindy session new` through a dedicated daemonization helper. Owns the device connection for the lifetime of the session. Listens on a Unix socket at `~/.haindy/sessions/<id>/daemon.sock`. Dispatches incoming commands to the appropriate agent and returns JSON. For long-running commands (`test`, `explore`), the daemon runs the work in a background task and returns an acknowledgement immediately.
+
+**Background Task Runner**: An internal component of the daemon that executes `test` and `explore` commands asynchronously. The daemon accepts the command, starts the background task, and returns a response immediately. The coding agent polls `test-status` or `explore-status` to track progress. Only one background task runs at a time per session (the device is sequential).
 
 **Action Agent**: Receives a natural language instruction, takes a screenshot via computer use, and either executes a single interaction (tap, click, type, scroll) or, for `session status`, observes the current screen and returns a natural-language description without taking action. Returns immediately with the result.
 
-**Test Runner**: Drives the Action Agent through a sequence of structured steps produced by the Test Planner, validating each step's expected outcome. Returns a pass/fail with a summary.
+**Test Runner**: Drives the Action Agent through a sequence of structured steps produced by the Test Planner, validating each step's expected outcome. Runs as a background task; progress is exposed via `test-status`.
 
-**Test Planner**: Accepts a high-level scenario description and produces a structured sequence of steps. Used by the `test` command.
+**Test Planner**: Accepts a detailed scenario description with explicit steps and expected outcomes, and produces a structured sequence of steps. Used by the `test` command. Requires unambiguous, detailed input from the coding agent.
 
-**Situational Agent** (v2): Will assess live device state from a screenshot to handle unknown starting conditions. Not used in v1. Required for the `explore` command.
+**Situational Agent**: Assesses live device state from a screenshot to determine the current screen context and decide how to proceed. Used by the `explore` command to handle unknown or changing screen states during open-ended exploration.
 
 ---
 
@@ -105,36 +113,65 @@ flowchart TD
 Each command maps to a different level of the agent stack:
 
 ```
-[v2] explore  ──►  Situational Agent + Test Planner + Test Runner + Action Agent
-     test     ──►  Test Planner + Test Runner + Action Agent
-     act      ──►  Action Agent only
+explore       ──►  Situational Agent + Test Planner + Test Runner + Action Agent  (async)
+test          ──►  Test Planner + Test Runner + Action Agent                      (async)
+act           ──►  Action Agent only                                              (sync)
 ```
 
-The coding agent should pick the lowest level that gives it what it needs:
-- Use `act` when the exact interaction is known and no validation is needed.
-- Use `test` for everything else: single-step validations, multi-step journeys, and open-ended scenarios.
-- `explore` is planned for v2 and requires live-screen situational assessment not yet implemented.
+The coding agent should pick the right level of abstraction:
+- Use `act` when the exact interaction is known and no validation is needed. Synchronous -- returns when the action completes.
+- Use `test` when the scenario is well-defined with explicit steps and expected outcomes. Asynchronous -- returns immediately; poll `test-status` for progress.
+- Use `explore` when the goal is open-ended and the current screen state is unknown or unpredictable. Asynchronous -- returns immediately; poll `explore-status` for progress.
 
 ---
 
 ## JSON Response Envelope
 
-Every command returns a single JSON object on stdout:
+Every command returns a single JSON object on stdout. There are two categories:
+
+### Synchronous commands (`act`, `screenshot`, `session *`)
+
+Return when the operation completes:
 
 ```json
 {
   "session_id": "string",
-  "command": "act | test | session",
+  "command": "act | screenshot | session",
   "status": "success | failure | error",
   "response": "Natural language description of what happened. Always present. Especially detailed on failure.",
   "screenshot_path": "/absolute/path/to/latest/screenshot.png",
   "meta": {
-    "exit_reason": "completed | assertion_failed | max_steps_reached | max_actions_reached | element_not_found | command_timeout | agent_error | device_error | session_busy",
+    "exit_reason": "completed | element_not_found | command_timeout | agent_error | device_error | session_busy",
     "duration_ms": 4821,
     "actions_taken": 7
   }
 }
 ```
+
+### Async dispatch commands (`test`, `explore`)
+
+Return immediately after the daemon accepts the command. The daemon takes an initial screenshot before dispatching the background task, so the response includes `screenshot_path` capturing the device state at the moment the command was received. The actual work runs in the background:
+
+```json
+{
+  "session_id": "string",
+  "command": "test | explore",
+  "status": "success | error",
+  "response": "Test dispatched. Poll test-status for progress.",
+  "screenshot_path": "/absolute/path/to/initial/screenshot.png",
+  "meta": {
+    "exit_reason": "dispatched",
+    "duration_ms": 52,
+    "actions_taken": 1
+  }
+}
+```
+
+### Status poll commands (`test-status`, `explore-status`)
+
+Return the current state of the running background task. See CLI_SPEC.md for the full response shape per command.
+
+### Common envelope fields
 
 | Field | Always present | Notes |
 |---|---|---|
@@ -142,10 +179,10 @@ Every command returns a single JSON object on stdout:
 | `command` | Yes | The subcommand that was run. |
 | `status` | Yes | Machine-readable signal. `error` means Haindy itself failed (bug/crash), `failure` means the action or assertion failed. |
 | `response` | Yes | Human-readable. On success: what happened. On failure: what was expected vs. what was observed. |
-| `screenshot_path` | Yes (when session active) | Absolute path to the latest screenshot. `null` if screenshot could not be taken or command has no device context. |
-| `meta.exit_reason` | Yes | Why the command terminated. Distinguishes `assertion_failed` from `element_not_found` from `command_timeout` from `session_busy` from `agent_error` etc. |
-| `meta.duration_ms` | Yes | Wall-clock time for the command in milliseconds. |
-| `meta.actions_taken` | Yes | Number of atomic device operations performed to satisfy the command. A fresh screenshot taken for `session status` counts as 1. Startup or teardown bookkeeping for `session new` and `session close` does not. |
+| `screenshot_path` | Yes (when session active) | Absolute path to the latest screenshot. `null` only for commands with no device context (e.g. `session list`, `session vars`). Async dispatch includes the initial screenshot taken at accept time. |
+| `meta.exit_reason` | Yes | Why the command terminated. Sync: `completed`, `element_not_found`, etc. Async dispatch: `dispatched`. Status polls: reflects the background task state. |
+| `meta.duration_ms` | Yes | Wall-clock time for the command in milliseconds. For status polls, this is the poll latency, not the background task elapsed time. |
+| `meta.actions_taken` | Yes | Number of atomic device operations performed. For async dispatch this is 1 (the initial screenshot). For status polls this reflects the background task's running total. |
 
 Exit codes mirror status: 0 for `success`, 1 for `failure` or `error`.
 
@@ -177,10 +214,13 @@ Exit codes mirror status: 0 for `success`, 1 for `failure` or `error`.
 | **Coding agent** | An AI coding assistant (Codex, Claude Code, etc.) using Haindy as a tool. |
 | **Session** | A persistent device connection owned by a daemon process, identified by a UUID. |
 | **Session daemon** | The background process that owns the device connection and dispatches commands. |
+| **Background task** | An async execution of `test` or `explore` running inside the daemon. One at a time per session. Polled via `test-status` or `explore-status`. |
 | **Session variable** | A named value stored in the session, referenced as `{{VAR}}` in commands. Secret variables are masked in logs and responses. |
 | **Skill** | A context-injection file that teaches a coding agent how to use `haindy` in tool call mode. Placed per-agent (e.g. `.claude/skills/` for Claude Code). |
 | **IPC** | Inter-process communication between CLI client and daemon, over a Unix domain socket. |
-| **act** | A single direct device interaction with no outcome validation. |
-| **test** | A scenario description run through the Test Planner and Test Runner, returning structured pass/fail. |
-| **explore** | (v2) An open-ended goal handled by the full agent stack including live-screen situational assessment. |
-| **exit_reason** | The `meta` field explaining why a command terminated: `completed`, `assertion_failed`, `max_steps_reached`, `max_actions_reached`, `element_not_found`, `command_timeout`, `agent_error`, `device_error`, or `session_busy`. |
+| **act** | A single direct device interaction with no outcome validation. Synchronous. |
+| **test** | A detailed, unambiguous scenario dispatched to the Test Planner and Test Runner. Asynchronous -- returns immediately; poll `test-status` for progress and results. |
+| **explore** | An open-ended goal handled by the Situational Agent + Test Planner + Test Runner. Asynchronous -- returns immediately; poll `explore-status` for progress and observations. |
+| **test-status** | Polls the progress of a running or completed `test` background task. |
+| **explore-status** | Polls the progress of a running or completed `explore` background task. |
+| **exit_reason** | The `meta` field explaining why a command terminated. Sync commands: `completed`, `element_not_found`, `command_timeout`, `agent_error`, `device_error`, `session_busy`. Async dispatch: `dispatched`. Background task results: `completed`, `assertion_failed`, `max_steps_reached`, `stuck`, `goal_reached`, `goal_unreachable`, `timeout`, `agent_error`, `device_error`. |

--- a/docs/design/tool-call-mode/SESSION_DAEMON.md
+++ b/docs/design/tool-call-mode/SESSION_DAEMON.md
@@ -168,9 +168,7 @@ sequenceDiagram
     participant CLI as haindy CLI
     participant D as Session Daemon
     participant BG as Background Task
-    participant SIT as Situational Agent
-    participant TP as Test Planner
-    participant TR as Test Runner
+    participant AWA as Awareness Agent
     participant AA as Action Agent
     participant DEV as Device
 
@@ -182,29 +180,26 @@ sequenceDiagram
     D-->>CLI: {"status": "success", "screenshot_path": "...", "meta": {"exit_reason": "dispatched"}}
     CLI-->>CA: Explore dispatched (with screenshot of entry state)
 
-    Note over BG,DEV: Background execution (async, iterative)
-    loop Until goal reached, stuck, or limits hit
-        BG->>SIT: assess(latest_screenshot, goal, observations_so_far)
-        Note over BG: First iteration uses the initial screenshot
-        SIT-->>BG: ScreenAssessment(description, next_actions, goal_status)
-        BG->>BG: Append to observations list
-        BG->>BG: Update current_focus
+    Note over BG,DEV: Background execution (async, tight loop)
+    BG->>AWA: bootstrap(goal, initial_screenshot)
+    AWA-->>BG: Initial state {todo[], current_focus, observations[]}
 
-        alt Goal reached
-            BG->>BG: Store result (goal_reached)
-        else Stuck / cannot proceed
-            BG->>BG: Store result (stuck)
-        else Continue exploring
-            BG->>TP: plan(next_actions)
-            TP-->>BG: MiniPlan(steps[])
-            BG->>TR: execute_plan(mini_plan)
-            loop For each step in mini_plan
-                TR->>AA: execute(step)
-                AA->>DEV: Perform action
-                DEV-->>AA: Done
-                AA-->>TR: ActionResult
-            end
-            TR-->>BG: MiniPlanResult
+    loop Until terminal state or limits hit
+        BG->>AWA: next_action(current_todo)
+        AWA-->>BG: TODO item to execute (or terminal decision)
+
+        alt Terminal decision (goal_reached / stuck / aborted)
+            BG->>BG: Store result and break loop
+        else Continue with next action
+            BG->>AA: execute(todo_item.action)
+            AA->>DEV: Perform action
+            DEV-->>AA: Done
+            AA-->>BG: ActionResult
+            BG->>DEV: Take post-action screenshot
+            DEV-->>BG: screen.png
+            BG->>AWA: assess(screen.png, last_action_result)
+            Note over AWA: Single model call: perception + decision.<br/>Updates TODO (mark done, add items, backtrack),<br/>appends observations, detects human intervention,<br/>decides continue / goal_reached / stuck / aborted.
+            AWA-->>BG: Updated state {todo[], current_focus, observations[], decision}
         end
     end
 
@@ -212,12 +207,16 @@ sequenceDiagram
     CA->>CLI: haindy explore-status --session <id>
     CLI->>D: {command: "explore_status"}
     D->>BG: read current state
-    BG-->>D: {explore_status, current_focus, observations, ...}
+    BG-->>D: {explore_status, current_focus, todo, observations, ...}
     D-->>CLI: JSON response
-    CLI-->>CA: {"explore_status": "in_progress|goal_reached|stuck", ...}
+    CLI-->>CA: {"explore_status": "in_progress|goal_reached|stuck|aborted", ...}
 ```
 
-The `explore` loop is iterative: assess the current screen, decide whether the goal has been reached or if progress is stuck, plan and execute a small batch of actions, then reassess. This continues until the goal is reached, the agent determines it cannot proceed, or an external limit (timeout, max-steps) is hit.
+The `explore` loop is intentionally tight: one Awareness Agent call per iteration that combines perception (what is on the screen), bookkeeping (update TODO and observations), and decision (continue, reach goal, give up, abort). The Awareness Agent calls the Action Agent directly for the next TODO item -- there is no Test Planner or Test Runner in this path, so there is no up-front plan to invalidate when assumptions turn out to be wrong.
+
+The TODO list is the agent's working memory. It is mutable: the Awareness Agent may add new items when it discovers a new screen, reorder items when it finds a shortcut, mark items `skipped` when they turn out to be unnecessary, and backtrack by pushing new items ahead of existing ones. The list is exposed verbatim in `explore-status` so the coding agent can see the trajectory.
+
+The Awareness Agent also watches for signs of human intervention on every iteration. If the screen shows an app or state that Haindy did not cause (foreign app in focus, device returned to the launcher, emulator restarted, unexpected system UI), and it cannot be recovered by adding a TODO item, the agent sets the terminal state to `aborted` and the background task ends. Transient interruptions like notifications or consent dialogs are handled inline by adding TODO items to dismiss or respond to them.
 
 ---
 
@@ -393,8 +392,8 @@ The daemon uses a single asyncio event loop. Device interaction is inherently se
 ## Implementation Notes
 
 - The daemon is implemented as a Python asyncio server using `asyncio.start_unix_server`.
-- Agent instances (ActionAgent, TestRunner, SituationalAgent, etc.) are created once at daemon startup and reused across commands, preserving any in-memory caches (e.g., coordinate caches).
+- Agent instances (ActionAgent, TestPlanner, TestRunner, AwarenessAgent) are created once at daemon startup and reused across commands, preserving any in-memory caches (e.g., coordinate caches). The standard-mode SituationalAgent is not instantiated by the daemon -- tool call mode uses the AwarenessAgent for live-screen perception instead.
 - The `WorkflowCoordinator` is not used in tool call mode. The daemon dispatches directly to agents. This avoids the planning overhead that is part of the full `run_test` flow.
 - Background tasks (`test`, `explore`) run as asyncio tasks within the daemon's event loop. The daemon maintains a reference to the active background task and its progress state. Status polls read this state without blocking.
-- The `explore` command uses an iterative loop: the Situational Agent assesses the screen, the Test Planner creates a small action plan, the Test Runner executes it, and the cycle repeats. Each iteration updates the `observations` list and `current_focus` field visible to `explore-status`.
+- The `explore` command uses a tight two-agent loop: the Awareness Agent maintains a living TODO list and calls the Action Agent directly for each next action, reassessing after every action. There is no Test Planner or Test Runner in the explore path. Each iteration updates `todo`, `observations`, and `current_focus` visible to `explore-status`. The Awareness Agent also detects human intervention (device moved, foreign app focused, emulator restarted) and can terminate the loop with `aborted`.
 - Screenshots are taken by the daemon (not the CLI) and written to the session screenshots directory. The response includes the absolute path. The coding agent is responsible for reading the file if it needs the image content. The coding agent can also take its own screenshots via the `screenshot` command at its own timing.

--- a/docs/design/tool-call-mode/SESSION_DAEMON.md
+++ b/docs/design/tool-call-mode/SESSION_DAEMON.md
@@ -22,17 +22,30 @@ stateDiagram-v2
     Spawning --> Initializing : independently launched daemon started
     Initializing --> Ready : device connected
 
-    Ready --> Executing : command received
-    Executing --> Ready : command complete (response sent)
-    Executing --> Ready : command failed (failure response sent)
-    Executing --> Error : unrecoverable exception
+    Ready --> SyncExec : sync command (act, screenshot, session *)
+    SyncExec --> Ready : response sent
+
+    Ready --> BgRunning : async dispatch (test, explore)
+    BgRunning --> BgRunning : status poll / session vars / screenshot
+    BgRunning --> Ready : background task completes
+
+    SyncExec --> Error : unrecoverable exception
+    BgRunning --> Error : unrecoverable exception
 
     Ready --> Closing : haindy session close
     Ready --> Closing : idle timeout reached
+    BgRunning --> Closing : haindy session close (cancels bg task)
     Error --> Closing : forced shutdown
 
     Closing --> [*] : daemon exits, socket removed
 ```
+
+The daemon distinguishes between synchronous commands (which block until done) and background tasks (which run asynchronously). While a background task is running:
+
+- **Allowed**: `test-status`, `explore-status`, `session set/unset/vars`, `session close`, `screenshot` (passive screen capture that does not interact with the device).
+- **Rejected**: `act`, `session status`, `test`, `explore`. These either interact with the device (conflicting with the background task) or attempt to start a second background task. The daemon returns `session_busy`.
+
+This ensures the background task has exclusive access to the device for interaction, while the coding agent can still poll progress, manage variables, and take passive screenshots.
 
 ---
 
@@ -96,23 +109,31 @@ sequenceDiagram
 
 ---
 
-## Command Dispatch Sequence: `test`
+## Command Dispatch Sequence: `test` (async)
 
 ```mermaid
 sequenceDiagram
     participant CA as Coding Agent
     participant CLI as haindy CLI
     participant D as Session Daemon
+    participant BG as Background Task
     participant TP as Test Planner
     participant TR as Test Runner
     participant AA as Action Agent
     participant DEV as Device
 
-    CA->>CLI: haindy test "sign in and verify dashboard"
+    CA->>CLI: haindy test "Step 1: tap email... Step 2: type..."
     CLI->>D: {command: "test", instruction: "..."}
-    D->>TP: plan(instruction)
-    TP-->>D: TestPlan(steps[])
-    D->>TR: execute_plan(plan)
+    D->>DEV: Take initial screenshot
+    DEV-->>D: entry_screen.png
+    D->>BG: spawn background task (with initial screenshot)
+    D-->>CLI: {"status": "success", "screenshot_path": "...", "meta": {"exit_reason": "dispatched"}}
+    CLI-->>CA: Test dispatched (with screenshot of entry state)
+
+    Note over BG,DEV: Background execution (async)
+    BG->>TP: plan(instruction, initial_screenshot)
+    TP-->>BG: TestPlan(steps[])
+    BG->>TR: execute_plan(plan)
 
     loop For each step in plan
         TR->>DEV: Take screenshot
@@ -122,24 +143,81 @@ sequenceDiagram
         DEV-->>AA: Done
         AA-->>TR: ActionResult
         TR->>TR: Verify step expected outcome
-        alt Step passed
-            TR->>TR: Advance to next step
-        else Step failed
-            TR-->>D: PlanResult(failed, failed_step_summary)
-        end
+        TR->>BG: Update progress (current_step, steps_completed)
     end
 
-    TR-->>D: PlanResult(status, summary)
-    D->>FS: Save final screenshot
-    D-->>CLI: JSON response (with meta)
-    CLI-->>CA: {"status": "success|failure", "response": "...", "meta": {...}}
+    TR-->>BG: PlanResult(status, summary)
+    BG->>BG: Store final result
+
+    Note over CA,CLI: Polling (at coding agent's pace)
+    CA->>CLI: haindy test-status --session <id>
+    CLI->>D: {command: "test_status"}
+    D->>BG: read current state
+    BG-->>D: {test_status, current_step, steps_completed, ...}
+    D-->>CLI: JSON response
+    CLI-->>CA: {"test_status": "in_progress|passed|failed", ...}
 ```
 
 ---
 
-## Command Dispatch Sequence: `explore` (v2 - not yet implemented)
+## Command Dispatch Sequence: `explore` (async)
 
-Placeholder for the v2 `explore` command. Requires live-screen situational assessment: the Situational Agent will take a screenshot, describe the current device state, and feed that into the Test Planner before execution begins. The sequence will be similar to `test` with a Situational Agent assessment step prepended.
+```mermaid
+sequenceDiagram
+    participant CA as Coding Agent
+    participant CLI as haindy CLI
+    participant D as Session Daemon
+    participant BG as Background Task
+    participant SIT as Situational Agent
+    participant TP as Test Planner
+    participant TR as Test Runner
+    participant AA as Action Agent
+    participant DEV as Device
+
+    CA->>CLI: haindy explore "find the notification settings"
+    CLI->>D: {command: "explore", instruction: "..."}
+    D->>DEV: Take initial screenshot
+    DEV-->>D: entry_screen.png
+    D->>BG: spawn background task (with initial screenshot)
+    D-->>CLI: {"status": "success", "screenshot_path": "...", "meta": {"exit_reason": "dispatched"}}
+    CLI-->>CA: Explore dispatched (with screenshot of entry state)
+
+    Note over BG,DEV: Background execution (async, iterative)
+    loop Until goal reached, stuck, or limits hit
+        BG->>SIT: assess(latest_screenshot, goal, observations_so_far)
+        Note over BG: First iteration uses the initial screenshot
+        SIT-->>BG: ScreenAssessment(description, next_actions, goal_status)
+        BG->>BG: Append to observations list
+        BG->>BG: Update current_focus
+
+        alt Goal reached
+            BG->>BG: Store result (goal_reached)
+        else Stuck / cannot proceed
+            BG->>BG: Store result (stuck)
+        else Continue exploring
+            BG->>TP: plan(next_actions)
+            TP-->>BG: MiniPlan(steps[])
+            BG->>TR: execute_plan(mini_plan)
+            loop For each step in mini_plan
+                TR->>AA: execute(step)
+                AA->>DEV: Perform action
+                DEV-->>AA: Done
+                AA-->>TR: ActionResult
+            end
+            TR-->>BG: MiniPlanResult
+        end
+    end
+
+    Note over CA,CLI: Polling (at coding agent's pace)
+    CA->>CLI: haindy explore-status --session <id>
+    CLI->>D: {command: "explore_status"}
+    D->>BG: read current state
+    BG-->>D: {explore_status, current_focus, observations, ...}
+    D-->>CLI: JSON response
+    CLI-->>CA: {"explore_status": "in_progress|goal_reached|stuck", ...}
+```
+
+The `explore` loop is iterative: assess the current screen, decide whether the goal has been reached or if progress is stuck, plan and execute a small batch of actions, then reassess. This continues until the goal is reached, the agent determines it cannot proceed, or an external limit (timeout, max-steps) is hit.
 
 ---
 
@@ -151,8 +229,8 @@ Communication between the CLI client and daemon uses newline-delimited JSON over
 
 ```json
 {
-  "command": "act | test | session_status | session_close | session_set | session_unset | session_vars",
-  "instruction": "string (for act/test)",
+  "command": "act | test | test_status | explore | explore_status | screenshot | session_status | session_close | session_set | session_unset | session_vars",
+  "instruction": "string (for act/test/explore)",
   "options": {
     "max_steps": 20,
     "timeout_seconds": 300,
@@ -201,7 +279,7 @@ process. The launcher:
 
 The daemon receives:
 - `--session-id <uuid>` - its own session ID
-- `--backend <android|desktop>` - device backend to initialize
+- `--backend <android|ios|desktop>` - device backend to initialize
 - A file descriptor number for the readiness pipe (via env var `HAINDY_READINESS_FD`)
 
 ### Idle timeout
@@ -219,7 +297,7 @@ a silent disappearance.
 
 ### Command timeout
 
-Every daemon-handled command is bounded by a wall-clock timeout. The caller may set it explicitly with `--timeout <seconds>`; otherwise the daemon uses the command default (300s for `test`, `act`, and `session status`).
+Synchronous commands (`act`, `screenshot`, `session status`) are bounded by a wall-clock timeout. The caller may set it explicitly with `--timeout <seconds>`; otherwise the daemon uses the command default (300s for `act` and `session status`, 30s for `screenshot`).
 
 If the timeout is reached, the daemon stops the command and returns:
 
@@ -233,6 +311,12 @@ If the timeout is reached, the daemon stops the command and returns:
   "meta": {"exit_reason": "command_timeout", "duration_ms": 300000, "actions_taken": 4}
 }
 ```
+
+### Background task timeout
+
+For async commands (`test`, `explore`), the `--timeout` flag sets the wall-clock budget for the background task, not the dispatch. The dispatch itself is instant. If the background task exceeds its timeout, it stops and records `timeout` as its terminal state. The next `test-status` or `explore-status` poll returns this result.
+
+For `test`, the default timeout is 300s. For `explore`, timeout is optional -- if omitted, explore runs until the goal is reached, the agent gets stuck, or max-steps is hit. The coding agent controls timing at its own level.
 
 ### Clean shutdown
 
@@ -273,32 +357,44 @@ This is an operational fallback, not the primary V1 path.
         daemon.log     # Rotating structured log for this session.
 ```
 
-Session directories are not automatically deleted after close. They serve as an audit trail. A separate `haindy session prune --older-than <days>` command can clean them up.
+Session directories are not automatically deleted after close. They serve as an audit trail. Use `haindy session prune --older-than <days>` to clean up old sessions (see CLI_SPEC.md).
 
 ---
 
 ## Concurrency
 
-The daemon is single-threaded per session. It processes one command at a time. If a second CLI process connects while a command is executing, it receives a `status: error` response:
+The daemon uses a single asyncio event loop. Device interaction is inherently sequential, so only one device-interacting operation runs at a time.
+
+**Sync command locking**: Sync commands (`act`, `screenshot`, `session status`) acquire a command lock. If a sync command is already executing, subsequent sync requests receive `session_busy`.
+
+**Background task exclusivity**: Only one background task (`test` or `explore`) runs at a time. Dispatching a second async command while one is active returns `session_busy`.
+
+**Coexistence rules while a background task is running**:
+- `test-status`, `explore-status`: always accepted (read-only state query).
+- `session set/unset/vars`: always accepted (metadata, no device interaction).
+- `screenshot`: accepted (passive screen capture, serialized with the background task's device access).
+- `session close`: accepted (cancels the background task and shuts down).
+- `act`, `session status`: rejected with `session_busy` (these interact with the device and would conflict with the background task).
+- `test`, `explore`: rejected with `session_busy` (only one background task at a time).
 
 ```json
 {
   "session_id": "...",
   "command": "...",
   "status": "error",
-  "response": "Session is busy executing a previous command. Retry when the current command completes.",
+  "response": "Session is busy executing a background task. Use test-status or explore-status to check progress, or session close to cancel.",
   "screenshot_path": null,
   "meta": {"exit_reason": "session_busy", "duration_ms": 0, "actions_taken": 0}
 }
 ```
-
-This is intentional. Device state is inherently sequential. Parallel commands on the same session would produce undefined behavior.
 
 ---
 
 ## Implementation Notes
 
 - The daemon is implemented as a Python asyncio server using `asyncio.start_unix_server`.
-- Agent instances (ActionAgent, TestRunner, etc.) are created once at daemon startup and reused across commands, preserving any in-memory caches (e.g., coordinate caches).
+- Agent instances (ActionAgent, TestRunner, SituationalAgent, etc.) are created once at daemon startup and reused across commands, preserving any in-memory caches (e.g., coordinate caches).
 - The `WorkflowCoordinator` is not used in tool call mode. The daemon dispatches directly to agents. This avoids the planning overhead that is part of the full `run_test` flow.
-- Screenshots are taken by the daemon (not the CLI) and written to the session screenshots directory. The response includes the absolute path. The coding agent is responsible for reading the file if it needs the image content.
+- Background tasks (`test`, `explore`) run as asyncio tasks within the daemon's event loop. The daemon maintains a reference to the active background task and its progress state. Status polls read this state without blocking.
+- The `explore` command uses an iterative loop: the Situational Agent assesses the screen, the Test Planner creates a small action plan, the Test Runner executes it, and the cycle repeats. Each iteration updates the `observations` list and `current_focus` field visible to `explore-status`.
+- Screenshots are taken by the daemon (not the CLI) and written to the session screenshots directory. The response includes the absolute path. The coding agent is responsible for reading the file if it needs the image content. The coding agent can also take its own screenshots via the `screenshot` command at its own timing.

--- a/docs/design/tool-call-mode/SKILL_SPEC.md
+++ b/docs/design/tool-call-mode/SKILL_SPEC.md
@@ -161,10 +161,13 @@ haindy explore-status --session <SESSION_ID>
 - `elapsed_time_seconds`: wall-clock time since dispatch
 
 **`explore-status` response fields:**
-- `explore_status`: `in_progress`, `goal_reached`, `stuck`, `timeout`, `max_steps_reached`, `error`
+- `explore_status`: `in_progress`, `goal_reached`, `stuck`, `aborted`, `timeout`, `max_steps_reached`, `error`
 - `current_focus`: what Haindy is currently trying to do (null when done)
+- `todo`: the Awareness Agent's living TODO list. Each entry is `{"action": string, "status": "pending" | "in_progress" | "done" | "skipped"}`. The list is mutable -- items may be added, reordered, or skipped as the agent learns more. Useful for understanding the trajectory and reconstructing what Haindy tried.
 - `observations`: accumulating list of factual observations about the app
 - `elapsed_time_seconds`: wall-clock time since dispatch
+
+Note: `explore` is driven by an Awareness Agent that maintains the TODO list and calls the Action Agent directly in a tight loop. It does not build a fixed plan up front, so it can freely backtrack when assumptions about the app turn out to be wrong. `aborted` specifically means the Awareness Agent detected that the device is no longer in a state Haindy produced (e.g. the target app lost focus, the emulator restarted, a user touched the device). It is distinct from `stuck`, which means Haindy tried and could not find a way forward on its own.
 
 **Timeout:** `test` defaults to 300s. `explore` has no default timeout -- it runs until the goal is reached, the agent gets stuck, or max-steps is hit. You can pass `--timeout <seconds>` to either command if you want to cap execution time.
 
@@ -200,8 +203,9 @@ Important: use the exact name you passed to `session set`. If you stored it as `
 - `timeout` - increase `--timeout` or split into smaller test calls.
 
 **For `explore`:** Check `explore-status` response fields.
-- `stuck` - the agent could not find a way forward. Read `observations` for what was discovered. Try a different goal or provide more context.
+- `stuck` - the agent tried and could not find a way forward. Read `observations` and the final `todo` for what was discovered and attempted. Try a different goal or provide more context.
 - `goal_reached` - read `observations` for what was discovered along the way.
+- `aborted` - something outside Haindy's control moved the device (user touched the emulator, another app stole focus, the emulator restarted). The session itself is still alive. Read the last screenshot and decide whether to restart the exploration or investigate manually. Do not treat this as a bug in the app under test.
 - `timeout` / `max_steps_reached` - the goal may be too broad. Try a more focused goal.
 
 **General:** `agent_error` or `device_error` means an internal failure. Read `response` for details.
@@ -377,8 +381,12 @@ test and explore return immediately. Poll for progress:
 test-status fields: test_status (in_progress|passed|failed|error|timeout|max_steps_reached),
 current_step, steps_total, steps_completed, steps_failed, issues_found, elapsed_time_seconds.
 
-explore-status fields: explore_status (in_progress|goal_reached|stuck|timeout|max_steps_reached|error),
-current_focus, observations (accumulating list), elapsed_time_seconds.
+explore-status fields: explore_status (in_progress|goal_reached|stuck|aborted|timeout|max_steps_reached|error),
+current_focus, todo (list of {action, status}), observations (accumulating list), elapsed_time_seconds.
+
+explore is driven by an Awareness Agent that maintains a living TODO list and backtracks freely.
+aborted means something external moved the device (user touched it, foreign app in focus, emulator restart).
+It is not an app bug -- diagnose and decide whether to restart the exploration.
 
 ## Screenshots
 
@@ -405,7 +413,9 @@ state at a specific moment -- Haindy's timing may not match yours.
 
 For act: element_not_found means target not visible. Do not retry same act more than twice.
 For test: read test-status. assertion_failed, max_steps_reached, timeout.
-For explore: read explore-status. stuck means agent could not proceed -- try a different goal.
+For explore: read explore-status. stuck means Haindy tried but could not find a way forward --
+try a different goal. aborted means the device left Haindy's control (user touched it, foreign
+app in focus, emulator restart) -- not a bug in the app under test.
 session_busy: a background task is running. Poll its status or close the session.
 ```
 

--- a/docs/design/tool-call-mode/SKILL_SPEC.md
+++ b/docs/design/tool-call-mode/SKILL_SPEC.md
@@ -32,20 +32,18 @@ The skill teaches the following in order:
 
 A one-paragraph summary. The agent needs to know Haindy is an external testing agent that controls a real device, not a mock or simulation.
 
-> Haindy is an autonomous testing agent that controls a real Android device (via ADB) or a desktop environment (via computer use). You issue natural language commands through its CLI and receive structured JSON results. Haindy runs as a background session daemon that keeps the device connection alive between your commands.
+> Haindy is an autonomous testing agent that controls a real Android device (via ADB), iOS device (via idb), or desktop environment (via computer use). You issue natural language commands through its CLI and receive structured JSON results. Haindy runs as a background session daemon that keeps the device connection alive between your commands.
 
 ### 2. Session Setup
 
 ```bash
-# Start a session (Android only)
+# Start a session (pick one backend)
 haindy session new --android [--android-serial <SERIAL>] [--android-app <PACKAGE>]
-
-# Start a session (desktop after the target app/site is already running)
+haindy session new --ios [--ios-udid <UDID>] [--ios-app <BUNDLE_ID>]
 haindy session new --desktop
 
 # Read `session_id` from the JSON response, then pass it explicitly:
 haindy session set USERNAME alice@example.com --session <SESSION_ID>
-haindy session set PASSWORD "$TEST_PASSWORD" --secret --session <SESSION_ID>
 haindy session set PASSWORD --value-file /run/secrets/test_password --secret --session <SESSION_ID>
 
 # Check current screen
@@ -61,7 +59,9 @@ Rule: For web projects, make sure the site or dev server is already running befo
 
 Rule: For native desktop app projects, make sure the app is already running before you start a desktop session. If needed, instruct Haindy to bring the app to the foreground using normal desktop UI actions. Prefer a maximized app window when possible.
 
-Rule: For mobile, only Android is supported in v1. Start the session against a device or emulator that ADB can reach, and pass `--android-serial` / `--android-app` when needed.
+Rule: For Android, start the session against a device or emulator that ADB can reach, and pass `--android-serial` / `--android-app` when needed.
+
+Rule: For iOS, start the session against a device or simulator that idb can reach, and pass `--ios-udid` / `--ios-app` when needed.
 
 Rule: Desktop sessions may downshift resolution for speed and token savings. Maximizing the target browser or app window helps keep screenshots focused on the app instead of surrounding desktop noise.
 
@@ -69,49 +69,108 @@ Rule: Use `haindy session set --secret` for credentials and tokens. Prefer `--va
 
 ### 3. Command Reference (compact)
 
+**Synchronous (return immediately with result):**
+
 ```
-haindy act  "<single action>" --session <SESSION_ID>  # direct device interaction, no validation
-haindy test "<scenario>" --session <SESSION_ID>       # planned multi-step test with pass/fail
-haindy session status --session <SESSION_ID>          # take screenshot and describe current screen state
-haindy session set <NAME> <VALUE> [--secret] --session <SESSION_ID>  # store a session variable
-haindy session set <NAME> --value-file <path> [--secret] --session <SESSION_ID>  # read a variable value from a file
+haindy act  "<instruction>" --session <SESSION_ID>      # single device interaction, no validation
+haindy screenshot --session <SESSION_ID>                 # capture screen without AI, return path
+haindy session status --session <SESSION_ID>             # AI describes current screen state
+haindy session set <NAME> <VALUE> [--secret] --session <SESSION_ID>
+haindy session set <NAME> --value-file <path> [--secret] --session <SESSION_ID>
+```
+
+**Asynchronous (dispatch and poll):**
+
+```
+haindy test "<scenario>" --session <SESSION_ID>          # dispatch test, returns immediately
+haindy test-status --session <SESSION_ID>                # poll test progress / result
+
+haindy explore "<goal>" --session <SESSION_ID>           # dispatch exploration, returns immediately
+haindy explore-status --session <SESSION_ID>             # poll explore progress / result
 ```
 
 ### 4. The JSON Response
 
-Every command returns JSON. The agent must read `status`, `response`, and `meta.exit_reason`:
+Every command returns JSON. Read `status`, `response`, and `meta.exit_reason`:
 
 ```json
 {
   "session_id": "...",
-  "command": "act|test|session",
+  "command": "act|test|test-status|explore|explore-status|screenshot|session",
   "status": "success|failure|error",
-  "response": "What happened in natural language.",
+  "response": "Natural language description of what happened.",
   "screenshot_path": "/absolute/path/to/screenshot.png",
-  "meta": {
-    "exit_reason": "completed|assertion_failed|max_steps_reached|element_not_found|command_timeout|agent_error|device_error|session_busy",
-    "duration_ms": 1243,
-    "actions_taken": 3
-  }
+  "meta": {"exit_reason": "...", "duration_ms": N, "actions_taken": N}
 }
 ```
 
 - `status: success` - proceed
 - `status: failure` - the action/assertion failed; read `response` for what was observed
 - `status: error` - Haindy itself failed; read `response` for diagnostic info
-- `meta.exit_reason` - why the command ended; use this to decide whether to retry or change approach
+- `meta.exit_reason` - why the command ended; use this to decide what to do next
 
 ### 5. Choosing the Right Command
 
 | Situation | Use |
 |---|---|
 | You know the exact UI element and action, no validation needed | `act` |
-| You want to validate an outcome, whether simple or complex | `test` |
-| You just want to see what is on screen | `session status` |
+| You have a detailed, unambiguous scenario with explicit steps and expected outcomes | `test` |
+| You have an open-ended goal and need Haindy to figure out the navigation | `explore` |
+| You want to see what is on screen (AI description) | `session status` |
+| You want a screenshot without AI processing | `screenshot` |
 
-Rule: **Prefer `test` over `act` when you care about the result.** `act` does not validate anything. If the tap succeeds but the expected outcome does not appear, `act` still returns `success`. Use `test` to validate both the action and the result.
+Rule: **Use `test` when you can write precise steps. Use `explore` when you cannot.** `test` requires detailed, unambiguous requirements. If you cannot describe the exact steps and expected outcomes, use `explore` with a goal instead.
 
-### 6. Session Variables
+Rule: **`act` does not validate anything.** If the tap succeeds but the expected outcome does not appear, `act` still returns `success`. Use `test` to validate both the action and the result.
+
+### 6. The Async Pattern: `test` and `explore`
+
+Both `test` and `explore` are asynchronous. They return immediately after dispatch. You poll for progress.
+
+**`test` requires detailed, unambiguous requirements.** Do not pass vague descriptions like "test the login flow". Instead, provide explicit steps, specific UI elements, concrete values, and clear expected outcomes. If you do not have enough detail, use `explore` or `session status` first.
+
+**`explore` accepts a goal.** The goal should be achievable by navigating visible UI. It does not need step-by-step instructions, but any context you provide (current app state, expected layout, relevant features) improves quality.
+
+**Polling pattern:**
+
+```bash
+# Dispatch
+haindy test "Step 1: Tap email field and type '{{USERNAME}}'. Step 2: Tap password field and type '{{PASSWORD}}'. Step 3: Tap 'Sign In'. Step 4: Verify dashboard appears with 'Welcome, Alice' header." --session <SESSION_ID>
+
+# Poll until done (test_status will be "in_progress", "passed", "failed", etc.)
+haindy test-status --session <SESSION_ID>
+# ... wait, then poll again ...
+haindy test-status --session <SESSION_ID>
+```
+
+```bash
+# Dispatch
+haindy explore "find the notification settings screen and report what options are available" --session <SESSION_ID>
+
+# Poll until done (explore_status will be "in_progress", "goal_reached", "stuck", etc.)
+haindy explore-status --session <SESSION_ID>
+# ... wait, then poll again ...
+haindy explore-status --session <SESSION_ID>
+```
+
+**`test-status` response fields:**
+- `test_status`: `in_progress`, `passed`, `failed`, `error`, `timeout`, `max_steps_reached`
+- `current_step`: what Haindy is currently executing (null when done)
+- `steps_total`, `steps_completed`, `steps_failed`: progress counters
+- `issues_found`: map of step identifiers to failure descriptions
+- `elapsed_time_seconds`: wall-clock time since dispatch
+
+**`explore-status` response fields:**
+- `explore_status`: `in_progress`, `goal_reached`, `stuck`, `timeout`, `max_steps_reached`, `error`
+- `current_focus`: what Haindy is currently trying to do (null when done)
+- `observations`: accumulating list of factual observations about the app
+- `elapsed_time_seconds`: wall-clock time since dispatch
+
+**Timeout:** `test` defaults to 300s. `explore` has no default timeout -- it runs until the goal is reached, the agent gets stuck, or max-steps is hit. You can pass `--timeout <seconds>` to either command if you want to cap execution time.
+
+**Screenshots:** The dispatch response for `test` and `explore` includes a `screenshot_path` capturing the device state at the moment the command was accepted. Status poll responses include the latest screenshot from the background task. Haindy's screenshot timing may not match the exact moment you need. Use `haindy screenshot --session <SESSION_ID>` to take your own screenshot at a time you choose.
+
+### 7. Session Variables
 
 Session variables let you store values once and reference them by name in subsequent commands:
 
@@ -119,68 +178,81 @@ Session variables let you store values once and reference them by name in subseq
 haindy session set USERNAME alice@example.com --session <SESSION_ID>
 haindy session set PASSWORD --value-file /run/secrets/test_password --secret --session <SESSION_ID>
 
-# Reference with {{NAME}} — shell-safe in both single- and double-quoted strings
-haindy test "sign in with {{USERNAME}} and {{PASSWORD}} and verify the dashboard appears" --session <SESSION_ID>
+# Reference with {{NAME}} -- shell-safe in both single- and double-quoted strings
+haindy test "Step 1: Type {{USERNAME}} into the email field. Step 2: Type {{PASSWORD}} into the password field. Step 3: Tap 'Sign In'. Step 4: Verify the dashboard loads." --session <SESSION_ID>
 haindy act "type {{USERNAME}} into the email field" --session <SESSION_ID>
 ```
 
 The daemon interpolates `{{NAME}}` tokens before passing the instruction to agents. Secret variables appear as `[redacted]` in any response text.
 
-Important: use the exact name you passed to `session set`. If you stored it as `USERNAME`, reference it as `{{USERNAME}}` — not `{{LOGIN_EMAIL}}`, `{{USER}}`, or any other variation.
+Important: use the exact name you passed to `session set`. If you stored it as `USERNAME`, reference it as `{{USERNAME}}` -- not `{{LOGIN_EMAIL}}`, `{{USER}}`, or any other variation.
 
-### 7. Handling Failures
+### 8. Handling Failures
 
-On `status: failure`, read `response` carefully - it describes what was observed vs. what was expected. Then check `meta.exit_reason` to decide how to respond:
+**For `act`:** On `status: failure`, read `response` and `meta.exit_reason`.
+- `element_not_found` - target not visible. Use `session status` or `screenshot` to check screen state.
+- `command_timeout` - action took too long. Break into simpler steps.
+- Do not retry the same `act` more than twice. Switch to `test` for better diagnostics.
 
-- `assertion_failed` - the action executed but the expected outcome did not occur. Adjust the `test` scenario or investigate the app state with `session status`.
-- `element_not_found` - the target was not visible. The app may still be loading, or the screen state is unexpected. Use `session status` to see the current screen.
-- `max_steps_reached` - Haindy ran out of steps without completing. Use `--max-steps` to allow more, or break the scenario into smaller `test` calls.
-- `command_timeout` - Haindy hit the command time limit. Retry with a larger `--timeout` or break the scenario into smaller commands.
-- `agent_error` or `device_error` - internal failure. Check `response` for details.
+**For `test`:** Check `test-status` response fields.
+- `assertion_failed` - action worked but expected outcome did not appear. Adjust the scenario or investigate with `session status`.
+- `max_steps_reached` - increase `--max-steps` or split into smaller test calls.
+- `timeout` - increase `--timeout` or split into smaller test calls.
 
-Do not retry the same `act` instruction more than twice. If a direct action is not working, switch to `test` with an explicit expected outcome to get more diagnostic information.
+**For `explore`:** Check `explore-status` response fields.
+- `stuck` - the agent could not find a way forward. Read `observations` for what was discovered. Try a different goal or provide more context.
+- `goal_reached` - read `observations` for what was discovered along the way.
+- `timeout` / `max_steps_reached` - the goal may be too broad. Try a more focused goal.
 
-### 8. Worked Example
+**General:** `agent_error` or `device_error` means an internal failure. Read `response` for details.
+
+### 9. Worked Example
 
 ```bash
-# 1. Start session and capture `session_id` from the JSON response
+# 1. Start session and set credentials
 haindy session new --android
 haindy session set USERNAME alice@example.com --session <SESSION_ID>
 haindy session set PASSWORD --value-file /run/secrets/test_password --secret --session <SESSION_ID>
 
-# 2. Check what we're looking at
-haindy session status --session <SESSION_ID>
-# response: "Device is on the home screen of the Android launcher."
+# 2. Explore to understand the app
+haindy explore "open the Acme app and find the sign-in screen" --session <SESSION_ID>
+# ... poll ...
+haindy explore-status --session <SESSION_ID>
+# explore_status: goal_reached
+# observations: ["Home screen shows Acme app icon", "App opened to welcome screen", "Welcome screen has 'Sign In' and 'Create Account' buttons"]
 
-# 3. Sign in and reach the dashboard
-haindy test "open the Acme app, sign in with {{USERNAME}} and {{PASSWORD}}, and verify the dashboard is shown" --session <SESSION_ID>
-# status: success
-# response: "Test passed in 3 steps. App opened, credentials entered, dashboard confirmed."
+# 3. Now we know the UI. Run a detailed test.
+haindy test "Step 1: Tap the 'Sign In' button on the welcome screen. Step 2: Tap the email field and type '{{USERNAME}}'. Step 3: Tap the password field and type '{{PASSWORD}}'. Step 4: Tap the 'Log In' button. Step 5: Verify the dashboard screen appears with text 'Welcome, Alice'." --session <SESSION_ID>
+# ... poll ...
+haindy test-status --session <SESSION_ID>
+# test_status: passed
+# steps_completed: 5, steps_failed: 0
 
-# 4. Validate a specific feature
-haindy test "tap on 'My Orders' and verify that a list of past orders is shown" --session <SESSION_ID>
-# status: success
+# 4. Explore a feature area
+haindy explore "navigate to the order history and report what orders are listed" --session <SESSION_ID>
+# ... poll ...
+haindy explore-status --session <SESSION_ID>
+# explore_status: goal_reached
+# observations: ["Dashboard has bottom nav: Home, Search, Orders, Profile", "Orders tab shows list of 3 past orders", "Most recent: Order #1234 - Blue Widget - Delivered"]
 
-# 5. Run a regression test
-haindy test "add item 'Blue Widget' to cart, proceed to checkout, enter shipping address '123 Main St', and verify the order summary shows the correct item and address" --session <SESSION_ID>
-# status: failure
-# meta.exit_reason: assertion_failed
-# response: "Failed at step 3. Items added to cart and checkout reached. Entering '123 Main St' showed a validation error: 'Please enter a valid street address with apartment number'. The field requires a more specific format."
-
-# 6. Close session
+# 5. Close session
 haindy session close --session <SESSION_ID>
 ```
 
-### 9. CI / Non-Interactive Use
+### 10. CI / Non-Interactive Use
 
-In CI pipelines, have the caller capture `.session_id` from the JSON response of `session new`, then pass it explicitly:
+In CI pipelines, capture `.session_id` from `session new`, then pass it explicitly:
 
 ```bash
 haindy session new --android
 # Caller stores the returned .session_id as <SESSION_ID>
-haindy session set USERNAME "$CI_TEST_USER" --session <SESSION_ID>  # shell expands $CI_TEST_USER here intentionally — that's the env var holding the value
+haindy session set USERNAME "$CI_TEST_USER" --session <SESSION_ID>
 haindy session set PASSWORD --value-file /run/secrets/ci_test_pass --secret --session <SESSION_ID>
-haindy test "complete onboarding flow" --session <SESSION_ID>
+
+haindy test "Step 1: Open app. Step 2: Sign in with {{USERNAME}} and {{PASSWORD}}. Step 3: Complete onboarding by tapping 'Next' three times and then 'Done'. Step 4: Verify the dashboard appears." --session <SESSION_ID>
+# Poll test-status until terminal state
+haindy test-status --session <SESSION_ID>
+
 haindy session close --session <SESSION_ID>
 ```
 
@@ -204,9 +276,17 @@ The most important thing to teach is that `response` is always a natural languag
 
 `status` tells the coding agent whether the command succeeded. `meta.exit_reason` tells it *why* it failed, which is what determines the correct recovery action. The skill must teach both.
 
-### Do not teach screenshot handling
+### Teach screenshot ownership
 
-The skill mentions `screenshot_path` exists but does not teach the coding agent how to read or display it. Coding agents already know how to read files. If the agent needs to look at the screenshot it will do so on its own.
+The skill must teach that `screenshot_path` in status responses is Haindy's screenshot, taken at Haindy's timing. The coding agent should use `haindy screenshot` to take its own screenshots when it needs to verify device state at a specific moment. Coding agents already know how to read image files.
+
+### Teach the async pattern explicitly
+
+The async dispatch-and-poll pattern for `test` and `explore` is the most important interaction pattern to get right. The skill must show the polling loop and explain the status fields. If the coding agent treats `test` as synchronous, it will block its own tool-use loop or hit tool call timeouts.
+
+### Teach requirement quality for `test`
+
+The `test` command requires detailed, unambiguous scenario descriptions. Vague inputs produce unreliable plans. The skill must show good examples (with explicit steps and assertions) and bad examples (vague one-liners) so the coding agent understands the quality bar.
 
 ---
 
@@ -217,28 +297,25 @@ The actual skill file content (adapt placement per agent):
 ```markdown
 # Using Haindy for device testing
 
-Haindy is an autonomous testing agent that controls a real Android device (via ADB)
-or a desktop environment (via computer use). You issue natural language commands
-through its CLI and receive structured JSON results.
+Haindy is an autonomous testing agent that controls a real Android device (via ADB),
+iOS device (via idb), or desktop environment (via computer use). You issue natural
+language commands through its CLI and receive structured JSON results.
 
 ## Session setup
 
     haindy session new --android [--android-serial <SERIAL>] [--android-app <PACKAGE>]
-    # or for desktop after the target app/site is already running:
+    haindy session new --ios [--ios-udid <UDID>] [--ios-app <BUNDLE_ID>]
     haindy session new --desktop
 
-Read `session_id` from the JSON response and pass it explicitly:
+Read `session_id` from the JSON response and pass it explicitly on every command.
 
-    haindy session status --session <SESSION_ID>
+Device startup rules:
+- Web: make sure the site or dev server is running before starting a desktop session.
+  If no browser is open, instruct Haindy to open one and navigate.
+- Desktop app: make sure the app is running, then instruct Haindy to bring it to foreground.
+- Prefer maximized windows. Desktop sessions may run at reduced resolution.
 
-Desktop/web startup rules:
-
-- For web projects, make sure the site or dev server is already running before starting the desktop session.
-- If a browser is not open, instruct Haindy to open one and navigate to the URL like a human would.
-- For native desktop apps, make sure the app is already running before starting the desktop session, then instruct Haindy to bring it to the foreground if needed.
-- Prefer a maximized browser or app window when possible. Desktop sessions may run at a reduced resolution for speed and token savings.
-
-Store credentials before using them in commands:
+Store credentials before using them:
 
     haindy session set USERNAME alice@example.com --session <SESSION_ID>
     haindy session set PASSWORD --value-file /run/secrets/test_password --secret --session <SESSION_ID>
@@ -249,48 +326,87 @@ Close the session when done:
 
 ## Commands
 
-    haindy act  "<instruction>" --session <SESSION_ID>   # single device interaction, no validation
-    haindy test "<scenario>" --session <SESSION_ID>      # planned multi-step test with pass/fail
-    haindy session status --session <SESSION_ID>         # take screenshot and describe current screen state
-    haindy session set <N> <V> [--secret] --session <SESSION_ID>  # store a session variable
-    haindy session set <N> --value-file <path> [--secret] --session <SESSION_ID>  # read a variable value from a file
+Synchronous (return with result):
 
-Reference session variables with {{NAME}} in any instruction string. The {{NAME}} syntax is
-shell-safe — it works in both single- and double-quoted strings without being expanded by the
-shell. Use the exact name you passed to `session set` — if you stored it as USERNAME, reference
-it as {{USERNAME}}.
+    haindy act "<instruction>" --session <SESSION_ID>      # single action, no validation
+    haindy screenshot --session <SESSION_ID>                # capture screen, no AI
+    haindy session status --session <SESSION_ID>            # AI describes current screen
+
+Asynchronous (dispatch and poll):
+
+    haindy test "<scenario>" --session <SESSION_ID>         # dispatch test
+    haindy test-status --session <SESSION_ID>               # poll progress/result
+
+    haindy explore "<goal>" --session <SESSION_ID>          # dispatch exploration
+    haindy explore-status --session <SESSION_ID>            # poll progress/result
+
+Reference session variables with {{NAME}} in any instruction string. Use the exact name
+you passed to `session set`.
+
+## test: requires detailed requirements
+
+Do NOT pass vague descriptions. Provide explicit steps, specific UI elements, values, and
+expected outcomes.
+
+Good:
+    haindy test "Step 1: Tap email field, type '{{USERNAME}}'. Step 2: Tap password field,
+    type '{{PASSWORD}}'. Step 3: Tap 'Sign In'. Step 4: Verify dashboard shows 'Welcome, Alice'."
+
+Bad:
+    haindy test "test the login"
+
+If you do not have enough detail for test, use explore or session status first.
+
+## explore: accepts a goal
+
+Pass a goal achievable by navigating visible UI. Does not need step-by-step instructions.
+
+    haindy explore "find the notification settings and report available options"
+
+explore has no default timeout. It runs until the goal is reached, the agent gets stuck,
+or max-steps is hit. Pass --timeout <seconds> to cap execution time.
+
+## Async polling pattern
+
+test and explore return immediately. Poll for progress:
+
+    haindy test "..." --session <SESSION_ID>
+    # poll until test_status is not "in_progress"
+    haindy test-status --session <SESSION_ID>
+
+test-status fields: test_status (in_progress|passed|failed|error|timeout|max_steps_reached),
+current_step, steps_total, steps_completed, steps_failed, issues_found, elapsed_time_seconds.
+
+explore-status fields: explore_status (in_progress|goal_reached|stuck|timeout|max_steps_reached|error),
+current_focus, observations (accumulating list), elapsed_time_seconds.
+
+## Screenshots
+
+The dispatch response for test and explore includes a screenshot of the device at accept time.
+Status poll responses include the latest screenshot from the background task. Take your own
+screenshots with `haindy screenshot --session <SESSION_ID>` when you need to verify device
+state at a specific moment -- Haindy's timing may not match yours.
 
 ## JSON response (always)
 
     {
       "session_id": "...",
-      "command": "act|test|session",
       "status": "success|failure|error",
-      "response": "Natural language description of what happened.",
-      "screenshot_path": "/absolute/path/to/screenshot.png",
+      "response": "Natural language description.",
+      "screenshot_path": "/path/to/screenshot.png",
       "meta": {"exit_reason": "...", "duration_ms": N, "actions_taken": N}
     }
 
 - status: success -> proceed
 - status: failure -> read response for what was observed vs. expected
 - status: error   -> Haindy internal failure, read response for diagnostics
-- meta.exit_reason -> why it ended: completed, assertion_failed, max_steps_reached,
-                      element_not_found, agent_error, device_error, session_busy
-
-## Choosing the right command
-
-- Use `act` only when you know the exact action and do not care about the outcome.
-- Use `test` for everything that requires outcome validation, simple or complex.
-- Use `session status` to orient before issuing commands to an unfamiliar screen.
 
 ## On failure
 
-Read `response` and `meta.exit_reason` before retrying.
-- assertion_failed: action worked but expected outcome did not appear.
-- element_not_found: target not visible; check screen state first.
-- max_steps_reached: increase --max-steps or split into smaller test calls.
-- session_busy: another command is already running; wait 5-10 seconds and retry once.
-Do not retry the same `act` more than twice. Switch to `test` for better diagnostics.
+For act: element_not_found means target not visible. Do not retry same act more than twice.
+For test: read test-status. assertion_failed, max_steps_reached, timeout.
+For explore: read explore-status. stuck means agent could not proceed -- try a different goal.
+session_busy: a background task is running. Poll its status or close the session.
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Redesign `test` and `explore` as async dispatch-and-poll commands (`test-status`, `explore-status`)
- `test` now requires detailed, unambiguous scenario descriptions; vague input rejected by design
- `explore` is driven by a new **Awareness Agent** that owns a tight loop, maintains a living TODO list, and calls the Action Agent directly (no Test Planner or Test Runner in the explore path)
- Awareness Agent detects human intervention and device loss on every iteration; terminal state `aborted` distinguishes "something external moved the device" from `stuck` ("Haindy tried and could not find a way forward")
- `explore-status` exposes the living `todo` list so coding agents can reconstruct the trajectory
- Both async commands take an initial screenshot on dispatch and return it in the response
- Add `session prune --older-than <days>` for session directory cleanup
- Add iOS backend (`--ios`, `--ios-udid`, `--ios-app`) throughout all docs
- Remove `--url` flag from `session new`
- Update concurrency model: sync commands and status polls allowed during background tasks, device-interacting commands rejected
- Rewrite skill template to teach async polling pattern, requirement quality for test, screenshot ownership, and `aborted` vs `stuck`

## Why the Awareness Agent

The first V2 round reused the standard-mode Situational Agent + Test Planner + Test Runner combo for explore. That turns out to be a poor fit for a loop: multiple model calls per iteration, the planner burns time producing a coherent plan, and the runner treats its own assumptions as assertions -- so a wrong assumption surfaces as an assertion failure rather than "update the TODO and try something else."

The new model is two agents only (Awareness + Action), one model call per iteration for perception + decision, and a mutable TODO list instead of a fixed plan. The standard-mode SituationalAgent is unrelated and unused in tool call mode.

## Files changed

- `docs/design/tool-call-mode/OVERVIEW.md` -- architecture diagram, command hierarchy, JSON envelope categories, glossary (Awareness Agent, TODO list, `aborted` exit_reason)
- `docs/design/tool-call-mode/CLI_SPEC.md` -- async test/explore, test-status/explore-status, session prune, JSON contract, explore `todo` field and `aborted` example
- `docs/design/tool-call-mode/SESSION_DAEMON.md` -- lifecycle states, sequence diagrams (explore loop rewritten around Awareness Agent), concurrency rules, background task timeout
- `docs/design/tool-call-mode/SKILL_SPEC.md` -- teaching sections, worked example, skill template, failure handling for `aborted`

## Test plan

- [x] Review all four design docs for internal consistency
- [x] Verify no stale V1 references remain (--url, synchronous test, explore placeholder)
- [x] Cross-check JSON contract examples match the contract reference table
- [x] Verify no stale Situational Agent or goal_unreachable references in explore path
