### PR TITLE
Fix Google structured output, add append_text_at, improve explore loop detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,23 +11,12 @@ repos:
       - id: check-json
       - id: detect-private-key
 
-  - repo: https://github.com/psf/black
-    rev: 26.1.0
-    hooks:
-      - id: black
-        language_version: python3
-
-  - repo: https://github.com/pycqa/isort
-    rev: 8.0.0
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.15.2
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1
@@ -37,3 +26,4 @@ repos:
           - types-aiofiles
           - pydantic
         args: ["--ignore-missing-imports"]
+        files: ^haindy/

--- a/docs/design/tool-call-mode/SKILL_SPEC.md
+++ b/docs/design/tool-call-mode/SKILL_SPEC.md
@@ -121,7 +121,7 @@ Every command returns JSON. Read `status`, `response`, and `meta.exit_reason`:
 |---|---|
 | You know the exact UI element and action, no validation needed | `act` |
 | You have explicit supporting documentation and want structured execution and validation for a substantial scenario | `test` |
-| You have an open-ended or undocumented goal and need Haindy to figure out the navigation | `explore` |
+| The goal is multi-step and you do not have written documentation (requirements, test plan, wireframes) to anchor a `test` command — even if you know the intended flow | `explore` |
 | You want to see what is on screen (AI description) | `session status` |
 | You want a screenshot without AI processing | `screenshot` |
 
@@ -139,9 +139,13 @@ Rule: Use `explore` when the task is complex but you do not have documentation t
 
 Rule: Use `explore` when you have partial knowledge, are learning the flow from the live app, or want Haindy to discover the reliable path through the UI.
 
+Rule: The absence of written documentation is what makes `explore` correct, not uncertainty about the UI. If you personally know the intended flow but have no documentation to anchor a `test` command, use `explore`.
+
 Rule: `explore` may still be given detailed instructions or a step-by-step objective. The difference is that those instructions are treated as guidance for discovery, not as a documented test case with authoritative expected outcomes.
 
 Rule: Use `act` when the task is atomic, when you want to drive the app one step at a time, or when you need to pause after each action to inspect screenshots and decide the next move.
+
+Rule: Each `act` call must contain exactly one atomic device interaction — one tap, one swipe, one text entry, one key press. Do not describe multiple interactions in a single call. If the task requires tap, then type, then submit, issue three separate `act` calls.
 
 Rule: If the task is small, sensitive, or requires close human oversight, prefer `act` with screenshot validation after every execution.
 

--- a/haindy/agents/computer_use/action_mixin.py
+++ b/haindy/agents/computer_use/action_mixin.py
@@ -422,15 +422,15 @@ class ComputerUseActionMixin:
                         )
                     await self._automation_driver.type_text(text_payload)
                     turn.status = "executed"
-                elif action_type == "type_text_at":
+                elif action_type in {"type_text_at", "append_text_at"}:
+                    clear_before = action_type == "type_text_at"
                     text_payload = action.get("text")
                     if text_payload is None:
                         raise ComputerUseExecutionError(
-                            "type_text_at action missing text."
+                            f"{action_type} action missing text."
                         )
                     press_enter_default = not normalized_coords
                     press_enter = bool(action.get("press_enter", press_enter_default))
-                    clear_before = bool(action.get("clear_before_typing", True))
                     if cached:
                         x, y = int(cached.x), int(cached.y)
                     else:

--- a/haindy/agents/computer_use/session.py
+++ b/haindy/agents/computer_use/session.py
@@ -206,6 +206,7 @@ class ComputerUseSession(
             "navigate",
             "click_at",
             "type_text_at",
+            "append_text_at",
             "key_combination",
             "hover_at",
             "drag_and_drop",
@@ -381,9 +382,7 @@ class ComputerUseSession(
         model_name = (
             self._google_model
             if self._provider == "google"
-            else self._openai_model
-            if self._provider == "openai"
-            else None
+            else self._openai_model if self._provider == "openai" else None
         )
         configured_timeout_seconds = self._action_timeout_seconds
         remaining_budget_seconds: float | None = None

--- a/haindy/agents/computer_use/session.py
+++ b/haindy/agents/computer_use/session.py
@@ -382,7 +382,9 @@ class ComputerUseSession(
         model_name = (
             self._google_model
             if self._provider == "google"
-            else self._openai_model if self._provider == "openai" else None
+            else self._openai_model
+            if self._provider == "openai"
+            else None
         )
         configured_timeout_seconds = self._action_timeout_seconds
         remaining_budget_seconds: float | None = None

--- a/haindy/agents/computer_use/support_mixin.py
+++ b/haindy/agents/computer_use/support_mixin.py
@@ -1026,7 +1026,8 @@ class ComputerUseSupportMixin:
                 "Stay inside the browser tab that is already open. Do NOT use alt+tab or open other desktop apps. "
                 "Use only these actions to interact with the page:\n"
                 "- click_at for buttons, inputs, and toggles (set button='right' for context clicks or click_count=2 for double clicks)\n"
-                "- type_text_at after clicking into inputs (set press_enter=true only when instructed)\n"
+                "- type_text_at after clicking into inputs — clears the field first, then types (set press_enter=true only when instructed)\n"
+                "- append_text_at to add text to an already-populated field without clearing it first\n"
                 "- scroll_at / scroll_document to move within the page\n"
                 "- key_combination for shortcuts like ctrl+l, ctrl+c, etc.\n"
                 "- read_clipboard to read copied text/URLs after using Copy actions\n"
@@ -1049,7 +1050,7 @@ class ComputerUseSupportMixin:
                 "IMPORTANT: You are controlling an Android phone through ADB-backed screenshots.\n"
                 + device_line
                 + "- Treat coordinates as positions on the provided mobile screenshot.\n"
-                "- Use mobile interactions only: click_at, type_text_at, scroll_at, wait_5_seconds, and the custom helpers long_press_at, go_home, and open_app when needed.\n"
+                "- Use mobile interactions only: click_at, type_text_at, append_text_at, scroll_at, wait_5_seconds, and the custom helpers long_press_at, go_home, and open_app when needed.\n"
                 "- Browser-style actions such as open_web_browser, search, navigate, hover_at, go_forward, scroll_document, drag_and_drop, and key_combination are unavailable in this mobile flow.\n"
                 "\n"
                 "GESTURE NAVIGATION:\n"
@@ -1063,7 +1064,7 @@ class ComputerUseSupportMixin:
                 "\n"
                 "GENERAL RULES:\n"
                 "- Do not use desktop assumptions, browser navigation actions, or desktop shortcuts like ctrl+a.\n"
-                "- For text entry, use type_text_at directly. Set press_enter=true only when the task explicitly says to submit or press Enter.\n"
+                "- For text entry, use type_text_at to clear the field and type fresh content. Use append_text_at to add to existing content without clearing. Set press_enter=true only when the task explicitly says to submit or press Enter.\n"
                 "- If masked password dots are visible after typing, treat the field as filled and stop retrying.\n\n"
                 + completion_instruction
                 + "YOUR TASK: "
@@ -1075,11 +1076,11 @@ class ComputerUseSupportMixin:
             ios_context = (
                 "IMPORTANT: You are controlling an iOS device (iPhone or iPad) through idb-backed screenshots.\n"
                 "- Treat coordinates as positions on the provided iOS screenshot.\n"
-                "- Use mobile interactions only: click_at, type_text_at, scroll_at, wait_5_seconds, and the custom helpers long_press_at and go_home when needed.\n"
+                "- Use mobile interactions only: click_at, type_text_at, append_text_at, scroll_at, wait_5_seconds, and the custom helpers long_press_at and go_home when needed.\n"
                 "- Browser-style actions such as open_web_browser, search, navigate, hover_at, go_forward, scroll_document, drag_and_drop, and key_combination are unavailable in this mobile flow.\n"
                 "- For system navigation, use the go_home helper to return to the iOS home screen.\n"
                 "- Do not use desktop assumptions, browser navigation actions, or desktop shortcuts.\n"
-                "- For text entry, use type_text_at directly. Set press_enter=true only when the task explicitly says to submit or press Enter.\n\n"
+                "- For text entry, use type_text_at to clear the field and type fresh content. Use append_text_at to add to existing content without clearing. Set press_enter=true only when the task explicitly says to submit or press Enter.\n\n"
                 + completion_instruction
                 + "YOUR TASK: "
             )
@@ -1095,7 +1096,8 @@ class ComputerUseSupportMixin:
             "Look for Slack (purple icon) or Firefox (orange/red icon) in the sidebar.\n\n"
             "AVAILABLE ACTIONS:\n"
             "- click_at: Click at screen coordinates (button='right' for context clicks, click_count=2 for double clicks)\n"
-            "- type_text_at: Click and type text (press Enter only if instructed)\n"
+            "- type_text_at: Clear the field and type fresh text (press Enter only if instructed)\n"
+            "- append_text_at: Add text to an already-populated field without clearing it\n"
             "- key_combination: Keyboard shortcuts like ctrl+c, enter\n"
             "- read_clipboard: Read copied text/URLs after using Copy actions\n"
             "- scroll_at / scroll_document: Scroll content\n"

--- a/haindy/config/agent_prompts.py
+++ b/haindy/config/agent_prompts.py
@@ -282,7 +282,14 @@ Rules:
 - Use `stuck` only when no reasonable next UI action remains
 - Use `aborted` only when something external clearly moved the device out of HAINDY's control
 - If continuing, exactly one TODO item should be `in_progress`
-- Do not invent hidden app structure that is not discoverable from the UI"""
+- Do not invent hidden app structure that is not discoverable from the UI
+
+Before updating the TODO list, read the skipped items:
+- Scan all items with status `skipped`. Each one represents an approach that was tried and did not achieve its sub-goal.
+- If you see multiple skipped items that share the same intent — regardless of how they are worded — you are in a loop. Do not add another item with that same intent.
+- Instead, reason about what those attempts have in common and why they all failed. What is the shared root cause? What assumption did they all make that turned out to be wrong?
+- The next item you add must address that root cause. It must represent a genuinely different strategy, not a rephrasing of the same action.
+- Examples of genuinely different strategies: if several attempts to type into a field all resulted in wrong text being entered, the root cause may be that the field was not empty or not focused before typing — so address that explicitly before typing. If several attempts to tap a button all failed, the button may be covered by an overlay — so dismiss the overlay first. If a search returned unexpected results repeatedly, the autocomplete may be interfering — so try a different input method or dismiss suggestions before submitting."""
 
 
 # Prompt Templates

--- a/haindy/desktop/virtual_input.py
+++ b/haindy/desktop/virtual_input.py
@@ -980,9 +980,11 @@ class VirtualInput:
             "kpmultiply": ecodes.KEY_KPASTERISK,
             "kpdot": ecodes.KEY_KPDOT,
         }
-        alias_map = {k: int(v) for k, v in alias_map.items() if v is not None}
-        if normalized in alias_map:
-            return alias_map[normalized]
+        alias_lookup: dict[str, int] = {
+            k: int(v) for k, v in alias_map.items() if v is not None
+        }
+        if normalized in alias_lookup:
+            return alias_lookup[normalized]
 
         if normalized.startswith("kp") and normalized[2:].isdigit():
             code = getattr(ecodes, f"KEY_KP{normalized[2:]}", None)

--- a/haindy/models/google_client.py
+++ b/haindy/models/google_client.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
+import re
 from inspect import isawaitable
 from typing import Any
 
@@ -11,15 +14,21 @@ from haindy.config.settings import get_settings
 from haindy.models.errors import ModelCallError
 from haindy.models.llm_client import dispatch_observer
 from haindy.models.openai_client import ResponseStreamObserver
+from haindy.models.structured_output import extract_json_schema_definition
 
 logger = logging.getLogger("google_client")
+
+_DATA_URL_PATTERN = re.compile(
+    r"^data:(?P<mime>image/[A-Za-z0-9.+-]+);base64,(?P<data>[A-Za-z0-9+/=\n\r]+)$",
+    re.DOTALL,
+)
 
 genai: Any | None
 genai_types: Any | None
 
 try:
-    import google.genai as genai
-    import google.genai.types as genai_types
+    import google.genai as genai  # type: ignore[no-redef]
+    import google.genai.types as genai_types  # type: ignore[no-redef]
 except ImportError:  # pragma: no cover - exercised in tests via monkeypatching
     genai = None
     genai_types = None
@@ -92,7 +101,53 @@ class GoogleClient:
             return f"{current}\n\n{normalized}"
         return normalized
 
-    def _make_part(self, text: str) -> Any:
+    @staticmethod
+    def _invalid_request_error(
+        message: str,
+        *,
+        payload: Any | None = None,
+    ) -> ModelCallError:
+        return ModelCallError(
+            message,
+            failure_kind="request_validation_error",
+            response_payload=payload,
+        )
+
+    @staticmethod
+    def _flatten_message_content(content: Any) -> str:
+        """Collapse mixed multimodal content into plain text for logging/system text."""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, dict):
+            text = content.get("text")
+            if isinstance(text, str):
+                return text
+            return str(content)
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict):
+                    item_type = str(item.get("type") or "").strip().lower()
+                    if item_type in {"text", "input_text", "output_text"}:
+                        text = item.get("text")
+                        if isinstance(text, str) and text:
+                            parts.append(text)
+                            continue
+                    if item_type in {"image", "image_url", "input_image"}:
+                        parts.append("<<attached image>>")
+                        continue
+                    image_url = item.get("image_url")
+                    if isinstance(image_url, (str, dict)):
+                        parts.append("<<attached image>>")
+                        continue
+                    if "text" in item and isinstance(item.get("text"), str):
+                        parts.append(item["text"])
+                        continue
+                parts.append(str(item))
+            return "\n".join(part for part in parts if part)
+        return str(content)
+
+    def _make_text_part(self, text: str) -> Any:
         if genai_types is None:
             raise RuntimeError(
                 "google-genai is required for the Google provider. "
@@ -102,6 +157,187 @@ class GoogleClient:
         if callable(from_text):
             return from_text(text=text)
         return genai_types.Part(text=text)
+
+    def _make_bytes_part(self, data: bytes, mime_type: str) -> Any:
+        if genai_types is None:
+            raise RuntimeError(
+                "google-genai is required for the Google provider. "
+                'Install it with `pip install "google-genai"`.'
+            )
+        from_bytes = getattr(genai_types.Part, "from_bytes", None)
+        if callable(from_bytes):
+            return from_bytes(data=data, mime_type=mime_type)
+        inline_data = getattr(genai_types, "Blob", None)
+        if inline_data is None:
+            raise RuntimeError(
+                "google-genai Part.from_bytes is unavailable in this SDK build."
+            )
+        return genai_types.Part(inline_data=inline_data(data=data, mime_type=mime_type))
+
+    def _make_uri_part(self, file_uri: str, mime_type: str | None = None) -> Any:
+        if genai_types is None:
+            raise RuntimeError(
+                "google-genai is required for the Google provider. "
+                'Install it with `pip install "google-genai"`.'
+            )
+        from_uri = getattr(genai_types.Part, "from_uri", None)
+        if callable(from_uri):
+            return from_uri(file_uri=file_uri, mime_type=mime_type)
+        file_data = getattr(genai_types, "FileData", None)
+        if file_data is None:
+            raise RuntimeError(
+                "google-genai Part.from_uri is unavailable in this SDK build."
+            )
+        return genai_types.Part(
+            file_data=file_data(file_uri=file_uri, mime_type=mime_type)
+        )
+
+    def _normalize_image_reference(
+        self,
+        reference: Any,
+        *,
+        mime_type: str | None = None,
+    ) -> Any:
+        if isinstance(reference, dict):
+            source = reference.get("source")
+            if isinstance(source, dict):
+                source_type = str(source.get("type") or "").strip().lower()
+                if source_type == "base64":
+                    return self._normalize_image_reference(
+                        {
+                            "data": source.get("data"),
+                            "mime_type": source.get("media_type")
+                            or source.get("mime_type")
+                            or mime_type,
+                        }
+                    )
+                if source_type in {"file", "uri", "url"}:
+                    return self._normalize_image_reference(
+                        source.get("file_uri")
+                        or source.get("uri")
+                        or source.get("url"),
+                        mime_type=source.get("mime_type")
+                        or source.get("media_type")
+                        or mime_type,
+                    )
+
+            nested_reference = (
+                reference.get("image_url")
+                or reference.get("url")
+                or reference.get("uri")
+                or reference.get("file_uri")
+            )
+            if nested_reference is not None:
+                return self._normalize_image_reference(
+                    nested_reference,
+                    mime_type=reference.get("mime_type")
+                    or reference.get("media_type")
+                    or mime_type,
+                )
+
+            raw_data = reference.get("data")
+            resolved_mime = str(
+                reference.get("mime_type")
+                or reference.get("media_type")
+                or mime_type
+                or ""
+            ).strip()
+            if raw_data is not None:
+                if not resolved_mime.startswith("image/"):
+                    raise self._invalid_request_error(
+                        "Google image bytes require an image/* mime_type.",
+                        payload={"image_reference": "<bytes>"},
+                    )
+                if isinstance(raw_data, str):
+                    try:
+                        raw_bytes = base64.b64decode(raw_data, validate=True)
+                    except (ValueError, binascii.Error) as exc:
+                        raise self._invalid_request_error(
+                            "Google image base64 inputs must contain valid base64 data.",
+                            payload={"image_reference": "<base64>"},
+                        ) from exc
+                    return self._make_bytes_part(raw_bytes, resolved_mime)
+                if isinstance(raw_data, (bytes, bytearray, memoryview)):
+                    return self._make_bytes_part(bytes(raw_data), resolved_mime)
+
+        if isinstance(reference, (bytes, bytearray, memoryview)):
+            resolved_mime = str(mime_type or "").strip()
+            if not resolved_mime.startswith("image/"):
+                raise self._invalid_request_error(
+                    "Google inline image bytes require an image/* mime_type.",
+                    payload={"image_reference": "<bytes>"},
+                )
+            return self._make_bytes_part(bytes(reference), resolved_mime)
+
+        if not isinstance(reference, str):
+            raise self._invalid_request_error(
+                "Unsupported Google image reference.",
+                payload={"image_reference": reference},
+            )
+
+        normalized = reference.strip()
+        data_url_match = _DATA_URL_PATTERN.match(normalized)
+        if data_url_match:
+            try:
+                image_bytes = base64.b64decode(
+                    data_url_match.group("data"), validate=True
+                )
+            except (ValueError, binascii.Error) as exc:
+                raise self._invalid_request_error(
+                    "Google image data URLs must contain valid base64 data.",
+                    payload={"image_reference": "<data-url>"},
+                ) from exc
+            return self._make_bytes_part(image_bytes, data_url_match.group("mime"))
+
+        if normalized.startswith(("http://", "https://", "file://", "gs://")):
+            return self._make_uri_part(normalized, mime_type)
+
+        raise self._invalid_request_error(
+            "Google image inputs must be image data URLs, image bytes, or URI-based file references.",
+            payload={"image_reference": reference},
+        )
+
+    def _normalize_content_item(self, item: Any) -> Any:
+        if isinstance(item, str):
+            return self._make_text_part(item)
+        if not isinstance(item, dict):
+            return self._make_text_part(str(item))
+
+        item_type = str(item.get("type") or "").strip().lower()
+        if item_type in {"text", "input_text", "output_text"}:
+            return self._make_text_part(str(item.get("text") or ""))
+
+        if item_type in {"image", "image_url", "input_image"} or "image_url" in item:
+            image_reference = item.get("image_url")
+            if image_reference is None:
+                image_reference = (
+                    item.get("url") or item.get("uri") or item.get("file_uri")
+                )
+            return self._normalize_image_reference(
+                image_reference,
+                mime_type=item.get("mime_type") or item.get("media_type"),
+            )
+
+        if item_type == "" and "text" in item:
+            return self._make_text_part(str(item.get("text") or ""))
+
+        raise self._invalid_request_error(
+            "Unsupported non-CU content block for Google.",
+            payload={"content_item": item},
+        )
+
+    def _normalize_message_content(self, content: Any) -> list[Any]:
+        # Gemini expects typed Part objects for multimodal inputs. If we coerce the
+        # mixed content list to str(), inline image data becomes plain text and can
+        # explode the token count.
+        if isinstance(content, list):
+            parts = [self._normalize_content_item(item) for item in content]
+            return parts or [self._make_text_part("")]
+        if isinstance(content, dict):
+            return [self._normalize_content_item(content)]
+        return [
+            self._make_text_part(content if isinstance(content, str) else str(content))
+        ]
 
     def _build_contents(
         self,
@@ -123,18 +359,17 @@ class GoogleClient:
             role = msg.get("role", "user")
             content = msg.get("content", "")
             if role == "system":
-                text = content if isinstance(content, str) else str(content)
+                text = self._flatten_message_content(content)
                 system_instruction = self._append_distinct_instruction(
                     system_instruction, text
                 )
                 continue
 
             google_role = "model" if role == "assistant" else "user"
-            text_content = content if isinstance(content, str) else str(content)
             google_contents.append(
                 genai_types.Content(
                     role=google_role,
-                    parts=[self._make_part(text_content)],
+                    parts=self._normalize_message_content(content),
                 )
             )
 
@@ -142,7 +377,7 @@ class GoogleClient:
             google_contents.append(
                 genai_types.Content(
                     role="user",
-                    parts=[self._make_part("")],
+                    parts=[self._make_text_part("")],
                 )
             )
 
@@ -181,6 +416,10 @@ class GoogleClient:
             config_kwargs["system_instruction"] = system_instruction
         if format_type in {"json_object", "json_schema"}:
             config_kwargs["response_mime_type"] = "application/json"
+        if format_type == "json_schema":
+            schema_def = extract_json_schema_definition(response_format)
+            if schema_def and schema_def.get("schema"):
+                config_kwargs["response_schema"] = schema_def["schema"]
 
         if genai_types is None:
             raise RuntimeError(

--- a/haindy/models/google_client.py
+++ b/haindy/models/google_client.py
@@ -419,7 +419,7 @@ class GoogleClient:
         if format_type == "json_schema":
             schema_def = extract_json_schema_definition(response_format)
             if schema_def and schema_def.get("schema"):
-                config_kwargs["response_schema"] = schema_def["schema"]
+                config_kwargs["response_json_schema"] = schema_def["schema"]
 
         if genai_types is None:
             raise RuntimeError(

--- a/haindy/skills/haindy/SKILL.md
+++ b/haindy/skills/haindy/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # Using HAINDY Tool-Call Mode
 
-HAINDY is an autonomous testing agent that controls a real Android device (via ADB), iOS device (via idb), or desktop environment (via computer use). You issue natural language commands through its CLI and receive structured JSON results. HAINDY runs as a background session daemon that keeps the device connection alive between your commands.
+HAINDY is an autonomous computer use agent that controls a real Android device (via ADB), iOS device (via idb), or desktop environment (via computer use). You issue natural language commands through its CLI and receive structured JSON results. HAINDY runs as a background session daemon that keeps the device connection alive between your commands.
 
 ## Session setup
 
@@ -23,8 +23,8 @@ Rules:
 - Web: make sure the site or dev server is already running before starting a desktop session. If no browser is open yet, instruct HAINDY to open one and navigate like a human would.
 - Native desktop app: make sure the app is already running before starting a desktop session. If needed, instruct HAINDY to bring it to the foreground.
 - Prefer maximized windows. Desktop sessions may downshift resolution for speed and token savings.
-- Android: start against a device or emulator ADB can reach, and pass `--android-serial` / `--android-app` when needed.
-- iOS: start against a device or simulator idb can reach, and pass `--ios-udid` / `--ios-app` when needed.
+- Android: check whether the target app is already open before trying to launch it. Prefer opening it through HAINDY computer use commands. Only fall back to launching it programmatically (e.g. via `--android-app`) as a last resort.
+- iOS: check whether the target app is already open before trying to launch it. Prefer opening it through HAINDY computer use commands. Only fall back to launching it programmatically (e.g. via `--ios-app`) as a last resort.
 - Use `haindy session set --secret` for credentials and tokens. Prefer `--value-file` when the value is sensitive.
 
 Store variables before using them:
@@ -41,90 +41,85 @@ haindy session close --session <SESSION_ID>
 haindy session prune --older-than 7
 ```
 
-## Commands
+## Choosing the right command
 
-```bash
-haindy act "<instruction>" --session <SESSION_ID>
-haindy screenshot --session <SESSION_ID>
-haindy session status --session <SESSION_ID>
-haindy session set <NAME> <VALUE> [--secret] --session <SESSION_ID>
-haindy session set <NAME> --value-file <PATH> [--secret] --session <SESSION_ID>
-haindy session unset <NAME> --session <SESSION_ID>
-haindy session vars --session <SESSION_ID>
+**Default: use `explore` or `act`. Use `test` only when explicitly asked to run a test suite.**
 
-haindy test "<scenario>" --session <SESSION_ID>
-haindy test-status --session <SESSION_ID>
-haindy explore "<goal>" --session <SESSION_ID>
-haindy explore-status --session <SESSION_ID>
-```
-
-Choose the right command:
-- `act`: exact interaction, no validation.
-- `test`: detailed, unambiguous scenario with explicit steps and expected outcomes.
-- `explore`: open-ended goal when you do not yet know a reliable step-by-step path.
-- `session status`: AI description of the current screen.
-- `screenshot`: raw screenshot without AI processing.
+| Command | Use when |
+|---|---|
+| `explore` | The goal spans multiple steps or requires navigating the app to find something. This is the default for interactive flows, demos, comparisons, and open-ended goals. |
+| `act` | You need a single, precise interaction and want to inspect the screen yourself before deciding the next step. |
+| `session status` | You want an AI description of the current screen without interacting. |
+| `screenshot` | You want a raw screenshot without AI processing. |
+| `test` | The user has explicitly asked for regression or system testing and has provided written specs, a test plan, Figma files, or other documentation to validate against. |
 
 Rules:
-- Use `test` when you can write precise steps. Use `explore` when you cannot.
-- `act` does not validate anything. If the tap succeeds but the expected result does not appear, `act` can still return `success`.
+- **`explore` is the default for any multi-step goal.** Navigating an app, opening a feature, comparing two platforms, running a demo flow — all of these are `explore`.
+- **`act` is for one atomic interaction per call.** One tap, one swipe, one text entry, one key press. Never chain multiple interactions in a single `act` call.
+- **`act` does not validate anything.** If the tap succeeds but the expected result does not appear, `act` still returns `success`. Use `session status` or `screenshot` after `act` to verify state.
+- **`test` is not a general-purpose multi-step driver.** Do not use it because a task has steps or an expected outcome. Only use `test` when the user explicitly asks for system or regression testing and provides documentation to validate against. If you are unsure whether `test` applies, it does not — use `explore`.
 
-## `test` requires detailed requirements
+## `explore`
 
-Do not pass vague one-liners. Provide explicit steps, specific UI elements, concrete values, and clear expected outcomes.
+The default command for anything that requires navigating the app. Pass a goal; HAINDY figures out the path.
 
-Good:
+```bash
+haindy explore "open the Maps app, search for Madrid, and report what the search results screen shows" --session <SESSION_ID>
+```
+
+`explore` runs until the goal is reached, the agent gets stuck, external interference aborts the run, or a limit is hit. Pass `--timeout <seconds>` to cap execution time.
+
+`explore` is driven by an Awareness Agent that maintains a living TODO list and can backtrack freely. `aborted` means something outside HAINDY moved the device or changed focus — that is not a bug in the app under test.
+
+## `act`
+
+For a single atomic interaction when you want direct control.
+
+```bash
+haindy act "tap the Maps icon" --session <SESSION_ID>
+haindy act "tap the search bar" --session <SESSION_ID>
+haindy act "type Madrid" --session <SESSION_ID>
+haindy act "tap the Search key on the keyboard" --session <SESSION_ID>
+```
+
+Each call is one interaction. Take a screenshot or `session status` between calls if you need to verify state before continuing.
+
+## `test` — restricted use only
+
+Only use `test` when the user has explicitly asked for regression or system testing and has provided documentation (specs, a test plan, wireframes, Figma) to validate against. Do not use `test` because the task is multi-step or has checkable outcomes — use `explore` for that.
 
 ```bash
 haindy test "Step 1: Tap the email field and type '{{USERNAME}}'. Step 2: Tap the password field and type '{{PASSWORD}}'. Step 3: Tap 'Sign In'. Step 4: Verify the dashboard appears with text 'Welcome, Alice' in the header." --session <SESSION_ID>
 ```
 
-Bad:
-
-```bash
-haindy test "test the login flow" --session <SESSION_ID>
-```
-
-If you do not have enough detail for `test`, use `explore` or `session status` first.
-
-## `explore` accepts a goal
-
-Pass a goal achievable by navigating visible UI. It does not need step-by-step instructions.
-
-```bash
-haindy explore "find the notification settings screen and report what options are available" --session <SESSION_ID>
-```
-
-`explore` runs until the goal is reached, the agent gets stuck, external interference aborts the run, or a limit is hit. Pass `--timeout <seconds>` if you want to cap execution time.
+Do not pass vague descriptions. Every step must name a specific UI element, a concrete value, and a clear expected outcome drawn from provided documentation.
 
 ## Async pattern
 
-`test` and `explore` dispatch background work and return immediately. They do not wait for the full run to finish.
+`explore` and `test` dispatch background work and return immediately. Poll for progress.
 
 ```bash
-haindy test "..." --session <SESSION_ID>
-haindy test-status --session <SESSION_ID>
-haindy test-status --session <SESSION_ID>
-
 haindy explore "..." --session <SESSION_ID>
 haindy explore-status --session <SESSION_ID>
 haindy explore-status --session <SESSION_ID>
+
+haindy test "..." --session <SESSION_ID>
+haindy test-status --session <SESSION_ID>
+haindy test-status --session <SESSION_ID>
 ```
 
 While a background task is active:
-- `act`, `session status`, `test`, and `explore` may return `session_busy`
-- `test-status`, `explore-status`, `screenshot`, `session set`, `session unset`, `session vars`, and `session close` are still allowed
+- `act`, `session status`, `explore`, and `test` may return `session_busy`
+- `explore-status`, `test-status`, `screenshot`, `session set`, `session unset`, `session vars`, and `session close` are still allowed
 - `session close` cancels the active background task before the daemon exits
 
 Read these fields on status polls:
 - `run_id`: stable async identifier for a `test` run
+- `explore_status`: `in_progress`, `goal_reached`, `stuck`, `aborted`, `timeout`, `max_steps_reached`, `error`
+- `current_focus`, `todo`, `observations`, `elapsed_time_seconds`
 - `test_status`: `in_progress`, `passed`, `failed`, `error`, `timeout`, `max_steps_reached`
 - `current_step`, `phase`, `last_model_agent`, `latest_action_artifact_path`
 - `steps_total`, `steps_completed`, `steps_failed`, `issues_found`, `elapsed_time_seconds`
-- `explore_status`: `in_progress`, `goal_reached`, `stuck`, `aborted`, `timeout`, `max_steps_reached`, `error`
-- `current_focus`, `todo`, `observations`, `elapsed_time_seconds`
-
-`explore` is driven by an Awareness Agent that maintains a living TODO list and can backtrack freely. `aborted` means something outside HAINDY moved the device or changed focus. That is not automatically a bug in the app under test.
 
 ## Session variables
 
@@ -136,7 +131,7 @@ haindy session set PASSWORD --value-file /run/secrets/test_password --secret --s
 
 # Reference with {{NAME}} in any instruction string
 haindy act "type {{USERNAME}} into the email field" --session <SESSION_ID>
-haindy test "Step 1: Type {{USERNAME}} into the email field. Step 2: Type {{PASSWORD}} into the password field. Step 3: Tap 'Sign In'. Step 4: Verify the dashboard loads." --session <SESSION_ID>
+haindy explore "sign in using {{USERNAME}} and {{PASSWORD}} and navigate to the account settings screen" --session <SESSION_ID>
 ```
 
 Rules:
@@ -148,7 +143,7 @@ Rules:
 
 ## Screenshots
 
-The dispatch response for `test` and `explore` includes a screenshot of the device at accept time. Status poll responses include the latest screenshot from the background task.
+The dispatch response for `explore` and `test` includes a screenshot of the device at accept time. Status poll responses include the latest screenshot from the background task.
 
 Use `haindy screenshot --session <SESSION_ID>` when you need a screenshot at your own chosen moment. HAINDY's screenshot timing may not match yours.
 
@@ -176,7 +171,7 @@ Important `exit_reason` values:
 
 ## On failure
 
+- For `explore`: `stuck` means HAINDY tried and could not find a way forward. `aborted` means the device left HAINDY's control. Read `observations`, `todo`, and the latest screenshot before deciding what to do next.
 - For `act`: `element_not_found` means the target is not visible. Use `session status` or `screenshot` to check screen state. Do not retry the same `act` more than twice.
 - For `test`: read `test-status`, not just the dispatch response. Check `assertion_failed`, `max_steps_reached`, `timeout`, `phase`, `current_step`, and `latest_action_artifact_path`.
-- For `explore`: `stuck` means HAINDY tried and could not find a way forward. `aborted` means the device left HAINDY's control. Read `observations`, `todo`, and the latest screenshot before deciding what to do next.
 - For any command: `agent_error` or `device_error` means HAINDY itself failed. Read `response` for diagnostics.

--- a/haindy/tool_call_mode/runtime.py
+++ b/haindy/tool_call_mode/runtime.py
@@ -883,6 +883,7 @@ class ToolCallSessionRuntime:
             return
 
         steps_taken = 0
+        _attempt_counts: dict[str, int] = {}
         while steps_taken < max_steps:
             next_action = self._next_explore_action(state.todo)
             if next_action is None:
@@ -891,6 +892,10 @@ class ToolCallSessionRuntime:
                 state.exit_reason = ExitReason.STUCK
                 state.response = "Exploration ended. No actionable TODO items remained."
                 return
+
+            action_key = next_action.action.strip()
+            _attempt_counts[action_key] = _attempt_counts.get(action_key, 0) + 1
+            consecutive_attempts = _attempt_counts[action_key]
 
             result = await self.action_agent.execute_tool_instruction(
                 next_action.action,
@@ -907,13 +912,17 @@ class ToolCallSessionRuntime:
                 result,
                 instruction=next_action.action,
             )
+            assess_context = {
+                **self._tool_context("explore"),
+                "consecutive_attempts_on_current_action": consecutive_attempts,
+            }
             assessment = await self.awareness_agent.assess(
                 goal=goal,
                 screenshot=screenshot_bytes,
                 todo=self._to_awareness_todo(state.todo),
                 observations=list(state.observations),
                 last_action_summary=last_action_summary,
-                context=self._tool_context("explore"),
+                context=assess_context,
             )
             self._apply_awareness_assessment(state, assessment)
             steps_taken += 1

--- a/tests/test_google_client.py
+++ b/tests/test_google_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+from collections.abc import AsyncGenerator, Generator
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,7 +29,7 @@ def _make_settings(
 
 
 @pytest.fixture()
-def patched_settings():
+def patched_settings() -> Generator[Any, None, None]:
     settings = _make_settings()
     with patch("haindy.models.google_client.get_settings", return_value=settings):
         yield settings
@@ -212,6 +214,102 @@ class TestGoogleClientCall:
         assert result["content"] == {"key": "value"}
 
     @pytest.mark.asyncio
+    async def test_json_schema_mode_forwards_response_schema(
+        self, patched_settings: Any
+    ) -> None:
+        from haindy.models.google_client import GoogleClient
+
+        response = _make_genai_response('{"decision": "continue"}')
+        captured_config: list[Any] = []
+
+        def _capture_config(**kwargs: Any) -> Any:
+            captured_config.append(kwargs)
+            return MagicMock()
+
+        schema = {
+            "type": "object",
+            "properties": {"decision": {"type": "string"}},
+            "required": ["decision"],
+            "additionalProperties": False,
+        }
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "test_schema", "schema": schema, "strict": True},
+        }
+
+        with (
+            patch("haindy.models.google_client.genai") as mock_genai,
+            patch("haindy.models.google_client.genai_types") as mock_types,
+        ):
+            mock_types.GenerateContentConfig = MagicMock(side_effect=_capture_config)
+            mock_types.Content = MagicMock(
+                side_effect=lambda role, parts: SimpleNamespace(role=role, parts=parts)
+            )
+            mock_types.Part = MagicMock()
+            mock_types.Part.from_text = MagicMock(
+                return_value=SimpleNamespace(text="x")
+            )
+            mock_client = MagicMock()
+            mock_client.aio = MagicMock()
+            mock_client.aio.models = MagicMock()
+            mock_client.aio.models.generate_content = AsyncMock(return_value=response)
+            mock_genai.Client = MagicMock(return_value=mock_client)
+
+            client = GoogleClient()
+            result = await client.call(
+                messages=[{"role": "user", "content": "go"}],
+                response_format=response_format,
+            )
+
+        assert result["content"] == {"decision": "continue"}
+        assert captured_config
+        config_kwargs = captured_config[0]
+        assert config_kwargs.get("response_mime_type") == "application/json"
+        assert config_kwargs.get("response_schema") == schema
+
+    @pytest.mark.asyncio
+    async def test_json_object_mode_does_not_forward_response_schema(
+        self, patched_settings: Any
+    ) -> None:
+        from haindy.models.google_client import GoogleClient
+
+        response = _make_genai_response('{"key": "value"}')
+        captured_config: list[Any] = []
+
+        def _capture_config(**kwargs: Any) -> Any:
+            captured_config.append(kwargs)
+            return MagicMock()
+
+        with (
+            patch("haindy.models.google_client.genai") as mock_genai,
+            patch("haindy.models.google_client.genai_types") as mock_types,
+        ):
+            mock_types.GenerateContentConfig = MagicMock(side_effect=_capture_config)
+            mock_types.Content = MagicMock(
+                side_effect=lambda role, parts: SimpleNamespace(role=role, parts=parts)
+            )
+            mock_types.Part = MagicMock()
+            mock_types.Part.from_text = MagicMock(
+                return_value=SimpleNamespace(text="x")
+            )
+            mock_client = MagicMock()
+            mock_client.aio = MagicMock()
+            mock_client.aio.models = MagicMock()
+            mock_client.aio.models.generate_content = AsyncMock(return_value=response)
+            mock_genai.Client = MagicMock(return_value=mock_client)
+
+            client = GoogleClient()
+            await client.call(
+                messages=[{"role": "user", "content": "go"}],
+                response_format={"type": "json_object"},
+            )
+
+        assert captured_config
+        config_kwargs = captured_config[0]
+        assert config_kwargs.get("response_mime_type") == "application/json"
+        assert "response_schema" not in config_kwargs
+
+    @pytest.mark.asyncio
     async def test_system_prompt_included_in_config(
         self, patched_settings: Any
     ) -> None:
@@ -321,7 +419,7 @@ class TestGoogleClientCall:
             def on_error(self, error: Any) -> None:
                 pass
 
-        async def _fake_stream(**kwargs: Any):
+        async def _fake_stream(**kwargs: Any) -> AsyncGenerator[Any, None]:
             yield chunk1
             yield chunk2
 
@@ -364,10 +462,10 @@ class TestGoogleClientCall:
 
         chunk = _make_genai_response("Hello")
 
-        async def _stream():
+        async def _stream() -> AsyncGenerator[Any, None]:
             yield chunk
 
-        async def _fake_stream(**kwargs: Any):
+        async def _fake_stream(**kwargs: Any) -> AsyncGenerator[Any, None]:
             return _stream()
 
         with (
@@ -501,3 +599,92 @@ class TestGoogleClientBuildContents:
 
         assert "model" in roles_created
         assert "user" in roles_created
+
+    def test_multimodal_content_uses_distinct_text_and_image_parts(
+        self, patched_settings: Any
+    ) -> None:
+        from haindy.models.google_client import GoogleClient
+
+        image_bytes = b"fake-png-bytes"
+        data_url = (
+            f"data:image/png;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+        )
+
+        with patch("haindy.models.google_client.genai_types") as mock_types:
+            contents_created: list[Any] = []
+
+            def _make_content(role: str, parts: Any) -> Any:
+                obj = SimpleNamespace(role=role, parts=parts)
+                contents_created.append(obj)
+                return obj
+
+            mock_types.Content = MagicMock(side_effect=_make_content)
+            mock_types.Part = MagicMock()
+            mock_types.Part.from_text = MagicMock(
+                side_effect=lambda *, text: SimpleNamespace(kind="text", text=text)
+            )
+            mock_types.Part.from_bytes = MagicMock(
+                side_effect=lambda *, data, mime_type: SimpleNamespace(
+                    kind="image", data=data, mime_type=mime_type
+                )
+            )
+
+            client = GoogleClient()
+            client._build_contents(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "Describe the image."},
+                            {"type": "input_image", "image_url": data_url},
+                        ],
+                    }
+                ],
+                system_prompt=None,
+            )
+
+        assert len(contents_created) == 1
+        assert contents_created[0].role == "user"
+        assert [part.kind for part in contents_created[0].parts] == ["text", "image"]
+        assert contents_created[0].parts[0].text == "Describe the image."
+        assert contents_created[0].parts[1].data == image_bytes
+        assert contents_created[0].parts[1].mime_type == "image/png"
+        mock_types.Part.from_text.assert_called_once_with(text="Describe the image.")
+        mock_types.Part.from_bytes.assert_called_once_with(
+            data=image_bytes,
+            mime_type="image/png",
+        )
+
+    def test_invalid_data_url_raises_request_validation_error(
+        self, patched_settings: Any
+    ) -> None:
+        from haindy.models.errors import ModelCallError
+        from haindy.models.google_client import GoogleClient
+
+        with patch("haindy.models.google_client.genai_types") as mock_types:
+            mock_types.Content = MagicMock(
+                side_effect=lambda role, parts: SimpleNamespace(role=role, parts=parts)
+            )
+            mock_types.Part = MagicMock()
+            mock_types.Part.from_text = MagicMock(
+                return_value=SimpleNamespace(kind="text", text="x")
+            )
+            mock_types.Part.from_bytes = MagicMock()
+
+            client = GoogleClient()
+            with pytest.raises(ModelCallError, match="valid base64 data"):
+                client._build_contents(
+                    [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_text", "text": "Describe the image."},
+                                {
+                                    "type": "input_image",
+                                    "image_url": "data:image/png;base64,a",
+                                },
+                            ],
+                        }
+                    ],
+                    system_prompt=None,
+                )

--- a/tests/test_google_client.py
+++ b/tests/test_google_client.py
@@ -265,7 +265,7 @@ class TestGoogleClientCall:
         assert captured_config
         config_kwargs = captured_config[0]
         assert config_kwargs.get("response_mime_type") == "application/json"
-        assert config_kwargs.get("response_schema") == schema
+        assert config_kwargs.get("response_json_schema") == schema
 
     @pytest.mark.asyncio
     async def test_json_object_mode_does_not_forward_response_schema(
@@ -307,7 +307,7 @@ class TestGoogleClientCall:
         assert captured_config
         config_kwargs = captured_config[0]
         assert config_kwargs.get("response_mime_type") == "application/json"
-        assert "response_schema" not in config_kwargs
+        assert "response_json_schema" not in config_kwargs
 
     @pytest.mark.asyncio
     async def test_system_prompt_included_in_config(


### PR DESCRIPTION
## Summary

- Fix Google Gemini client not forwarding the response schema for structured output — was using `response_schema` (Google-native format) instead of `response_json_schema` (standard JSON Schema), which rejected nullable types like `["string", "null"]`
- Rewrite haindy skill to make `explore` the default command and restrict `test` to cases with explicit written documentation
- Add `append_text_at` action as the non-destructive counterpart to `type_text_at` — clears before typing vs appends without clearing, making the distinction explicit and teachable to CU models
- Teach the awareness agent to detect and break explore loops by scanning skipped TODO items for shared intent, reasoning about the root cause, and requiring a genuinely different strategy rather than a rephrasing of what already failed

## Test plan

- [x] Google structured output fix tested end-to-end with Gemini via live explore sessions
- [x] `append_text_at` tested on iOS simulator
- [x] Explore loop detection tested on iOS Maps search scenario — agent now converges in ~6 actions vs 15+ actions before, and reaches `goal_reached` reliably
- [x] All unit tests passing (`pytest`)
- [x] mypy, ruff, black clean