### PR TITLE
Improve setup wizard UX

### DIFF
--- a/haindy/cli/doctor.py
+++ b/haindy/cli/doctor.py
@@ -28,6 +28,10 @@ def _na(notes: str = "") -> tuple[Text, str]:
     return Text("N/A", style="dim"), notes
 
 
+def _not_set(notes: str = "") -> tuple[Text, str]:
+    return Text("NOT SET", style="yellow dim"), notes
+
+
 def _check_python_version() -> tuple[Text, str]:
     vi = sys.version_info
     version_str = f"{vi.major}.{vi.minor}.{vi.micro}"
@@ -50,9 +54,9 @@ def _check_api_key(provider: str) -> tuple[Text, str]:
 
         if get_api_key(provider):
             return _ok("")
-        return _missing(f"run: haindy auth login {provider}")
+        return _not_set(f"run: haindy auth login {provider}")
     except Exception:
-        return _missing(f"run: haindy auth login {provider}")
+        return _not_set(f"run: haindy auth login {provider}")
 
 
 def _check_codex_oauth() -> tuple[Text, str]:
@@ -67,9 +71,9 @@ def _check_codex_oauth() -> tuple[Text, str]:
                     f"token expired ({label}) — run: haindy auth login openai-codex"
                 )
             return _ok(label)
-        return _missing("run: haindy auth login openai-codex")
+        return _not_set("run: haindy auth login openai-codex")
     except Exception:
-        return _missing("run: haindy auth login openai-codex")
+        return _not_set("run: haindy auth login openai-codex")
 
 
 def _check_macos_pynput() -> tuple[Text, str]:
@@ -189,16 +193,28 @@ def run_doctor() -> int:
     _add("haindy package", status, notes)
 
     status, notes = _check_api_key("openai")
-    _add("OpenAI credentials", status, notes)
+    openai_ok = status.plain == "OK"
+    _add("OpenAI credentials", status, notes, required=False)
 
     status, notes = _check_api_key("anthropic")
-    _add("Anthropic credentials", status, notes)
+    anthropic_ok = status.plain == "OK"
+    _add("Anthropic credentials", status, notes, required=False)
 
     status, notes = _check_api_key("vertex")
-    _add("Google credentials", status, notes)
+    google_ok = status.plain == "OK"
+    _add("Google credentials", status, notes, required=False)
 
     status, notes = _check_codex_oauth()
-    _add("OpenAI Codex (OAuth)", status, notes)
+    codex_ok = status.plain == "OK"
+    _add("OpenAI Codex (OAuth)", status, notes, required=False)
+
+    if openai_ok or anthropic_ok or google_ok or codex_ok:
+        _add("AI provider (at least one)", *_ok())
+    else:
+        _add(
+            "AI provider (at least one)",
+            *_missing("run: haindy auth login openai / anthropic / google"),
+        )
 
     # macOS desktop deps — backend-specific, not individually required
     if sys.platform == "darwin":

--- a/haindy/cli/setup_wizard.py
+++ b/haindy/cli/setup_wizard.py
@@ -91,6 +91,7 @@ def _wizard(non_interactive: bool) -> int:
         _console.print(f"Settings file: [dim]not found[/dim] ({settings_path})")
 
     _console.rule("Step 2: AI CLI Skill Installation")
+    installed_clis: list[str] = []
     for cli_binary, (setup_target, main_target) in AI_CLIS.items():
         if shutil.which(cli_binary) is None:
             continue
@@ -103,6 +104,7 @@ def _wizard(non_interactive: bool) -> int:
             )
         if should_install:
             _install_skills(cli_binary, setup_target, main_target)
+            installed_clis.append(cli_binary)
 
     _console.rule("Step 3: Dependency Check")
     doctor_code = run_doctor()
@@ -226,10 +228,26 @@ def _wizard(non_interactive: bool) -> int:
     if final_code == 0:
         _SETUP_MARKER.parent.mkdir(parents=True, exist_ok=True)
         _SETUP_MARKER.touch()
-        _console.print(
-            "\n[green]Setup complete![/green] Run:\n\n"
-            "  haindy run --plan <requirements_file> --context <context_file>\n"
-        )
+
+        if installed_clis:
+            agents = " or ".join(installed_clis)
+            _console.print(
+                f"\n[green]Setup complete.[/green] Open {agents} and use the "
+                f"[bold]haindy[/bold] skill to run your first task. For example:\n\n"
+                f"  Use the haindy skill to open a desktop session, get a screenshot "
+                f"and tell me what you see.\n\n"
+                f"[dim]Note: you may need to restart any open agent sessions for the "
+                f"skill to load.[/dim]\n"
+            )
+        else:
+            _console.print(
+                "\n[green]Setup complete.[/green] Open your AI coding agent and use "
+                "the [bold]haindy[/bold] skill to run your first task. For example:\n\n"
+                "  Use the haindy skill to open a desktop session, get a screenshot "
+                "and tell me what you see.\n\n"
+                "[dim]Note: you may need to restart any open agent sessions for the "
+                "skill to load.[/dim]\n"
+            )
         return 0
 
     _console.print(

--- a/haindy/cli/setup_wizard.py
+++ b/haindy/cli/setup_wizard.py
@@ -241,14 +241,14 @@ def _wizard(non_interactive: bool) -> int:
             )
         else:
             _console.print(
-                "\n[green]Setup complete.[/green] You can run Haindy directly from "
-                "the CLI:\n\n"
-                "  haindy run --plan <your_plan.txt> --context <your_context.txt>\n\n"
-                "See [bold]docs/RUNBOOK.md[/bold] for how to write plan and context "
-                "files.\n\n"
+                "\n[green]Setup complete.[/green] Open your favourite coding agent "
+                "and give it this prompt:\n\n"
+                "  Run `haindy session new --desktop` to start a desktop session, "
+                "then run `haindy screenshot --session <SESSION_ID>` and tell me "
+                "what you see on screen.\n\n"
                 "[dim]Tip: install claude, codex, or opencode and re-run "
-                "[bold]haindy setup[/bold] to get the agent skill, which lets you "
-                "drive Haindy conversationally.[/dim]\n"
+                "[bold]haindy setup[/bold] to get the haindy skill, which makes "
+                "this much simpler.[/dim]\n"
             )
         return 0
 

--- a/haindy/cli/setup_wizard.py
+++ b/haindy/cli/setup_wizard.py
@@ -175,16 +175,24 @@ def _wizard(non_interactive: bool) -> int:
                     },
                 )
             elif not non_interactive:
+                from haindy.config.settings_file import load_settings_file
+
+                _sd = load_settings_file(_sp)
+                current_ncu = _sd.get("agent", {}).get("provider", "")
+                current_cu = _sd.get("computer_use", {}).get("provider", "")
+
                 _console.print("Which provider should handle planning and analysis?")
                 for i, p in enumerate(available, 1):
-                    _console.print(f"  [{i}] {p}")
+                    marker = " [dim](current)[/dim]" if p == current_ncu else ""
+                    _console.print(f"  [{i}] {p}{marker}")
                 choice_ncu = input(
                     f"Choice (1-{len(available)}, or press Enter to keep current): "
                 ).strip()
 
                 _console.print("Which provider should handle computer use?")
                 for i, p in enumerate(available, 1):
-                    _console.print(f"  [{i}] {p}")
+                    marker = " [dim](current)[/dim]" if p == current_cu else ""
+                    _console.print(f"  [{i}] {p}{marker}")
                 choice_cu = input(
                     f"Choice (1-{len(available)}, or press Enter to keep current): "
                 ).strip()

--- a/haindy/cli/setup_wizard.py
+++ b/haindy/cli/setup_wizard.py
@@ -241,12 +241,14 @@ def _wizard(non_interactive: bool) -> int:
             )
         else:
             _console.print(
-                "\n[green]Setup complete.[/green] Open your AI coding agent and use "
-                "the [bold]haindy[/bold] skill to run your first task. For example:\n\n"
-                "  Use the haindy skill to open a desktop session, get a screenshot "
-                "and tell me what you see.\n\n"
-                "[dim]Note: you may need to restart any open agent sessions for the "
-                "skill to load.[/dim]\n"
+                "\n[green]Setup complete.[/green] You can run Haindy directly from "
+                "the CLI:\n\n"
+                "  haindy run --plan <your_plan.txt> --context <your_context.txt>\n\n"
+                "See [bold]docs/RUNBOOK.md[/bold] for how to write plan and context "
+                "files.\n\n"
+                "[dim]Tip: install claude, codex, or opencode and re-run "
+                "[bold]haindy setup[/bold] to get the agent skill, which lets you "
+                "drive Haindy conversationally.[/dim]\n"
             )
         return 0
 

--- a/haindy/cli/setup_wizard.py
+++ b/haindy/cli/setup_wizard.py
@@ -240,15 +240,22 @@ def _wizard(non_interactive: bool) -> int:
                 f"skill to load.[/dim]\n"
             )
         else:
+            try:
+                skill_path = str(
+                    importlib.resources.files("haindy.skills") / "haindy" / "SKILL.md"
+                )
+            except Exception:
+                skill_path = "haindy/skills/haindy/SKILL.md"
             _console.print(
                 "\n[green]Setup complete.[/green] Open your favourite coding agent "
                 "and give it this prompt:\n\n"
                 "  Run `haindy session new --desktop` to start a desktop session, "
                 "then run `haindy screenshot --session <SESSION_ID>` and tell me "
                 "what you see on screen.\n\n"
-                "[dim]Tip: install claude, codex, or opencode and re-run "
-                "[bold]haindy setup[/bold] to get the haindy skill, which makes "
-                "this much simpler.[/dim]\n"
+                f"[dim]Tip: if you have claude, codex, or opencode installed, "
+                f"re-run [bold]haindy setup[/bold] to install the haindy skill and "
+                f"skip the manual prompting. For other coding agents, install the "
+                f"skill manually from {skill_path}[/dim]\n"
             )
         return 0
 

--- a/haindy/cli/setup_wizard.py
+++ b/haindy/cli/setup_wizard.py
@@ -76,7 +76,7 @@ def _wizard(non_interactive: bool) -> int:
         "  - (optional) Mobile testing tools (Android ADB or iOS idb)\n"
     )
 
-    _console.rule("Step 2: Environment Detection")
+    _console.rule("Step 1: Environment Detection")
     platform_label = {
         "darwin": "macOS",
         "linux": "Linux",
@@ -90,7 +90,7 @@ def _wizard(non_interactive: bool) -> int:
     else:
         _console.print(f"Settings file: [dim]not found[/dim] ({settings_path})")
 
-    _console.rule("Step 3: AI CLI Skill Installation")
+    _console.rule("Step 2: AI CLI Skill Installation")
     for cli_binary, (setup_target, main_target) in AI_CLIS.items():
         if shutil.which(cli_binary) is None:
             continue
@@ -104,7 +104,7 @@ def _wizard(non_interactive: bool) -> int:
         if should_install:
             _install_skills(cli_binary, setup_target, main_target)
 
-    _console.rule("Step 4: Dependency Check")
+    _console.rule("Step 3: Dependency Check")
     doctor_code = run_doctor()
     if not non_interactive and doctor_code != 0:
         _console.print(
@@ -112,7 +112,7 @@ def _wizard(non_interactive: bool) -> int:
             "Review the table above for installation instructions.[/yellow]"
         )
 
-    _console.rule("Step 5: Credential Setup")
+    _console.rule("Step 4: Credential Setup")
     try:
         from haindy.auth.credentials import get_api_key
         from haindy.cli.auth_commands import handle_auth_login
@@ -140,7 +140,7 @@ def _wizard(non_interactive: bool) -> int:
             if Confirm.ask(f"Set up {provider} credentials now?", default=True):
                 asyncio.run(handle_auth_login(provider))
 
-    _console.rule("Step 6: Provider Selection")
+    _console.rule("Step 5: Provider Selection")
     try:
         from haindy.auth import OpenAIAuthManager
         from haindy.auth.credentials import list_configured_providers
@@ -220,7 +220,7 @@ def _wizard(non_interactive: bool) -> int:
     except Exception as exc:
         _console.print(f"[yellow]Provider selection skipped ({exc}).[/yellow]")
 
-    _console.rule("Step 7: Final Check")
+    _console.rule("Step 6: Final Check")
     final_code = run_doctor()
 
     if final_code == 0:

--- a/haindy/cli/setup_wizard.py
+++ b/haindy/cli/setup_wizard.py
@@ -178,14 +178,16 @@ def _wizard(non_interactive: bool) -> int:
                 _console.print("Which provider should handle planning and analysis?")
                 for i, p in enumerate(available, 1):
                     _console.print(f"  [{i}] {p}")
-                _console.print("  [s] Skip -- keep current setting")
-                choice_ncu = input(f"Choice (1-{len(available)}/s): ").strip()
+                choice_ncu = input(
+                    f"Choice (1-{len(available)}, or press Enter to keep current): "
+                ).strip()
 
                 _console.print("Which provider should handle computer use?")
                 for i, p in enumerate(available, 1):
                     _console.print(f"  [{i}] {p}")
-                _console.print("  [s] Skip -- keep current setting")
-                choice_cu = input(f"Choice (1-{len(available)}/s): ").strip()
+                choice_cu = input(
+                    f"Choice (1-{len(available)}, or press Enter to keep current): "
+                ).strip()
 
                 ncu_prov = (
                     available[int(choice_ncu) - 1]


### PR DESCRIPTION
## Summary

- Renumber wizard steps 2-7 to 1-6 (the banner is the title, not a step)
- Change individual provider credential rows in `doctor.py` from required to optional; use a new `NOT SET` status (dim yellow) instead of `MISSING` (red) to signal unconfigured-but-not-a-blocker
- Add an aggregate `AI provider (at least one)` required row that only fails when zero providers are configured, so a single working provider produces a clean setup-complete result
- Keep `MISSING` (red) for the Codex OAuth expired case, which requires real action
- Fix provider selection prompt: remove `[s] Skip` list item (Rich was rendering `--` as strikethrough) and move the default action into the prompt text instead
- Mark the current provider with `(current)` in each selection list so users know what is already active
- Add a tailored next-step message after setup completes: names the specific agent CLIs where skills were installed, includes an example prompt, and adds a restart note
- When no skills were installed, show a prompt the user can paste into any coding agent using direct CLI commands (`haindy session new --desktop` + `haindy screenshot`), plus a tip pointing to the bundled skill file for manual installation

## Test plan

- [x] Run `haindy setup` with multiple providers configured and verify steps are numbered 1-6
- [x] Run `haindy setup` with only one provider configured and verify the final check passes (no "setup incomplete")
- [x] Verify `NOT SET` appears in dim yellow for unconfigured providers in the doctor table
- [x] Verify provider selection lists show `(current)` next to the active provider
- [x] Verify pressing Enter at provider selection keeps the current setting
- [x] Run `haindy setup` with a supported agent CLI present and verify the completion message names it
- [x] Run `haindy setup` with no supported agent CLI and verify the CLI-command prompt is shown