### PR TITLE
Add pre-filled GitHub issue URLs for user feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ pytest                # tests
 | `haindy/orchestration/` | Multi-agent workflow coordination |
 | `haindy/monitoring/` | JSONL logging, HTML report generation |
 
+## Reporting issues
+
+Both batch and tool-call modes emit a pre-filled GitHub issue URL with run
+context (HAINDY version, platform, command, exit reason, truncated error).
+Batch mode prints it at the end of a run; tool-call mode adds a `feedback_url`
+field to the JSON envelope on failure. Set `HAINDY_NO_FEEDBACK_URL=1` to
+suppress it.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and how to submit changes.

--- a/docs/design/FEEDBACK.md
+++ b/docs/design/FEEDBACK.md
@@ -1,0 +1,112 @@
+# Feedback URLs Design
+
+## Overview
+
+HAINDY is an open-source, early-stage tool. We want a lightweight way for users to
+report issues without running telemetry infrastructure. The first iteration uses
+pre-filled GitHub issue URLs. No server, no data leaves the user's machine until
+they choose to click the link.
+
+This covers two surfaces:
+
+1. **Batch mode** (`haindy run ...`) — a human invokes HAINDY directly. We can
+   print a human-readable call-to-action at the end of the run.
+2. **Tool-call mode** (`haindy act`, `haindy test`, `haindy explore`, ...) — an
+   AI coding agent (Claude Code, Codex, OpenCode) invokes HAINDY. The agent
+   reads the JSON envelope but the human eventually sees the agent's summary.
+   We surface the feedback URL as a field in the JSON envelope so agents relay
+   it when reporting a failure.
+
+## Design
+
+### Module
+
+New module `haindy/feedback.py` exposes two helpers:
+
+- `build_issue_url(*, command: str, exit_reason: str | None, error: str | None,
+  run_id: str | None, extra: dict[str, str] | None = None) -> str`
+- `console_feedback_hint(url: str) -> str` — one-line Rich-safe string for batch
+  mode output.
+
+The URL points at `https://github.com/Haindy/haindy/issues/new` with query
+parameters:
+
+| Param | Source |
+|-------|--------|
+| `title` | `[haindy <version>] <command>: <exit_reason or "issue">` |
+| `body` | Rendered markdown template (see below) |
+| `labels` | `user-feedback` |
+
+The body template captures everything a maintainer needs to triage a bug,
+pre-filled so users only add the narrative:
+
+```
+<!-- Pre-filled by HAINDY. Edit freely. -->
+
+**Command:** haindy <command>
+**HAINDY version:** <version>
+**Platform:** <platform>
+**Python:** <python_version>
+**Run ID:** <run_id or "n/a">
+**Exit reason:** <exit_reason or "n/a">
+
+### What happened
+<truncated error text, if any>
+
+### What I expected
+
+### Steps to reproduce
+```
+
+Body length is capped at ~6000 characters before URL encoding to stay under
+GitHub's ~8KB URL limit. The error snippet is truncated first.
+
+### Batch mode integration
+
+In `haindy/main.py`, after the report is written (both success and failure
+paths) and on the top-level error paths (`ScopeTriageBlockedError`,
+`asyncio.TimeoutError`, generic `Exception`), print one line:
+
+```
+Feedback or bug? https://github.com/Haindy/haindy/issues/new?<pre-filled>
+```
+
+On keyboard interrupt we skip the hint (the user already decided to abort).
+
+### Tool-call mode integration
+
+Add an optional `feedback_url: str | None` field to `ToolCallEnvelope`. The
+field is populated only when `status != success`, to keep happy-path envelopes
+lean. Populated at the top of `run_tool_call_cli` / `run_tool_call_daemon_cli`
+right before `model_dump_json()`.
+
+Agents that relay tool results to humans (Claude Code, Codex) will include the
+URL in their summary when a call fails, giving the human a one-click path to
+report the problem.
+
+### Opt-out
+
+Respect `HAINDY_NO_FEEDBACK_URL=1`. When set:
+
+- Batch mode prints no hint.
+- Tool-call mode leaves `feedback_url` as `None`.
+
+No allow-list or rate limit. The URL is generated locally; there is no
+outbound request.
+
+## Non-goals
+
+- **Passive telemetry** (metrics, crash reports, anonymous usage pings). Out of
+  scope for v1. A follow-up design can add this if we ever want it.
+- **In-app issue submission**. Users always land on github.com to review the
+  pre-filled body before submitting — no surprise data exfiltration.
+- **Per-agent attribution** in tool-call mode. The envelope already carries
+  `session_id`, `run_id`, and `command`; that's enough context in the body.
+
+## Privacy
+
+The pre-filled body contains: HAINDY version, Python version, platform string
+(from `platform.platform()`), command name, exit reason, run id, and a
+truncated error message. No API keys, file contents, screenshots, or user
+prompts. The user still reviews and edits the body on github.com before
+submitting.

--- a/haindy/feedback.py
+++ b/haindy/feedback.py
@@ -1,0 +1,120 @@
+"""Pre-filled GitHub issue URLs for user feedback and bug reports.
+
+No telemetry, no outbound requests. Generates a URL that the user (or the
+human behind an AI coding agent) can click to land on github.com with an issue
+body pre-populated with run context. The user still reviews and edits before
+submitting.
+"""
+
+from __future__ import annotations
+
+import os
+import platform as _platform
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from urllib.parse import urlencode
+
+
+def _detect_version() -> str:
+    try:
+        return version("haindy")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+_HAINDY_VERSION = _detect_version()
+
+ISSUE_URL_BASE = "https://github.com/Haindy/haindy/issues/new"
+ISSUE_LABELS = "user-feedback"
+OPT_OUT_ENV_VAR = "HAINDY_NO_FEEDBACK_URL"
+
+# GitHub tolerates ~8KB URLs. Leave headroom for encoding overhead and base URL.
+MAX_BODY_CHARS = 6000
+MAX_ERROR_SNIPPET_CHARS = 2000
+
+
+def feedback_enabled() -> bool:
+    """Return ``False`` when the user has opted out via env var."""
+
+    return os.environ.get(OPT_OUT_ENV_VAR, "").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - len("\n... [truncated]")] + "\n... [truncated]"
+
+
+def _render_body(
+    *,
+    command: str,
+    run_id: str | None,
+    exit_reason: str | None,
+    error: str | None,
+) -> str:
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    error_block = _truncate(error.strip(), MAX_ERROR_SNIPPET_CHARS) if error else "_(none)_"
+
+    body = (
+        "<!-- Pre-filled by HAINDY. Edit freely before submitting. -->\n"
+        "\n"
+        f"**Command:** `haindy {command}`\n"
+        f"**HAINDY version:** {_HAINDY_VERSION}\n"
+        f"**Platform:** {_platform.platform()}\n"
+        f"**Python:** {python_version}\n"
+        f"**Run ID:** {run_id or 'n/a'}\n"
+        f"**Exit reason:** {exit_reason or 'n/a'}\n"
+        "\n"
+        "### What happened\n"
+        f"{error_block}\n"
+        "\n"
+        "### What I expected\n"
+        "\n"
+        "\n"
+        "### Steps to reproduce\n"
+    )
+    return _truncate(body, MAX_BODY_CHARS)
+
+
+def _render_title(command: str, exit_reason: str | None) -> str:
+    tail = exit_reason or "issue"
+    return f"[haindy {_HAINDY_VERSION}] {command}: {tail}"
+
+
+def build_issue_url(
+    *,
+    command: str,
+    run_id: str | None = None,
+    exit_reason: str | None = None,
+    error: str | None = None,
+) -> str | None:
+    """Build a pre-filled GitHub issue URL for the given run context.
+
+    Returns ``None`` when the user has opted out via ``HAINDY_NO_FEEDBACK_URL``.
+    """
+
+    if not feedback_enabled():
+        return None
+
+    params = {
+        "title": _render_title(command, exit_reason),
+        "body": _render_body(
+            command=command,
+            run_id=run_id,
+            exit_reason=exit_reason,
+            error=error,
+        ),
+        "labels": ISSUE_LABELS,
+    }
+    return f"{ISSUE_URL_BASE}?{urlencode(params)}"
+
+
+def console_feedback_hint(url: str) -> str:
+    """Return a Rich-formatted one-liner pointing users at the issue URL."""
+
+    return f"[dim]Hit a bug or have feedback? Open a pre-filled issue:[/dim] [link]{url}[/link]"

--- a/haindy/main.py
+++ b/haindy/main.py
@@ -34,6 +34,7 @@ from haindy.core.types import ScopeTriageResult, TestPlan, TestState
 from haindy.desktop.controller import DesktopController
 from haindy.desktop.screen_recorder import ScreenRecorder, ScreenRecorderError
 from haindy.error_handling import ScopeTriageBlockedError
+from haindy.feedback import build_issue_url, console_feedback_hint
 from haindy.mobile.controller import MobileController
 from haindy.mobile.ios_controller import IOSController
 from haindy.monitoring.debug_logger import initialize_debug_logger
@@ -317,15 +318,34 @@ async def run_test(
         if actions_path:
             console.print(f"[green]Actions saved to:[/green] {actions_path}")
 
+        _print_feedback_hint(
+            command="run",
+            run_id=test_run_id,
+            exit_reason=str(status_value),
+            error=None if status_value in success_statuses else f"Status: {status_value}",
+        )
+
         return 0 if status_value in success_statuses else 1
 
     except ScopeTriageBlockedError as scope_error:
         logger.warning("Context/scope gate blocked planning", exc_info=True)
         _print_scope_blockers(scope_error)
+        _print_feedback_hint(
+            command="run",
+            run_id=get_run_id(),
+            exit_reason="scope_blocked",
+            error=str(scope_error) or "Scope triage blocked planning.",
+        )
         return 1
     except asyncio.TimeoutError:
         console.print(
             f"\n[red]Error: Test execution timed out after {timeout} seconds[/red]"
+        )
+        _print_feedback_hint(
+            command="run",
+            run_id=get_run_id(),
+            exit_reason="timeout",
+            error=f"Test execution timed out after {timeout} seconds.",
         )
         return 2
     except KeyboardInterrupt:
@@ -334,6 +354,12 @@ async def run_test(
     except Exception as exc:
         console.print(f"\n[red]Error during test execution: {exc}[/red]")
         logger.exception("Test execution failed")
+        _print_feedback_hint(
+            command="run",
+            run_id=get_run_id(),
+            exit_reason=type(exc).__name__,
+            error=str(exc),
+        )
         return 1
     finally:
         if screen_recorder:
@@ -464,6 +490,25 @@ def _print_scope_blockers(error: ScopeTriageBlockedError) -> None:
         console.print("\n[bold yellow]Additional notes[/bold yellow]")
         for item in additional:
             console.print(f"- {item}")
+
+
+def _print_feedback_hint(
+    *,
+    command: str,
+    run_id: str | None,
+    exit_reason: str | None,
+    error: str | None,
+) -> None:
+    """Print a pre-filled GitHub issue URL unless the user has opted out."""
+
+    url = build_issue_url(
+        command=command,
+        run_id=run_id,
+        exit_reason=exit_reason,
+        error=error,
+    )
+    if url:
+        console.print(console_feedback_hint(url))
 
 
 def _render_plan_table(test_plan: TestPlan) -> None:

--- a/haindy/tool_call_mode/cli.py
+++ b/haindy/tool_call_mode/cli.py
@@ -102,8 +102,15 @@ class ToolCallArgumentParser(argparse.ArgumentParser):
 def is_tool_call_command(argv: list[str] | None) -> bool:
     """Return True when argv targets the tool-call command surface."""
 
+    command = _extract_tool_call_command(argv)
+    return command is not None
+
+
+def _extract_tool_call_command(argv: list[str] | None) -> str | None:
+    """Return the tool-call subcommand in ``argv``, or ``None`` if absent."""
+
     if not argv:
-        return False
+        return None
     index = 0
     while index < len(argv):
         token = argv[index]
@@ -113,8 +120,8 @@ def is_tool_call_command(argv: list[str] | None) -> bool:
         if token == "--session":
             index += 2
             continue
-        return token in TOOL_CALL_COMMANDS
-    return False
+        return token if token in TOOL_CALL_COMMANDS else None
+    return None
 
 
 def _add_legacy_commands(
@@ -643,7 +650,8 @@ async def run_tool_call_cli(argv: list[str]) -> int:
     try:
         args = parser.parse_args(argv)
     except ToolCallUsageError as exc:
-        envelope, exit_code = _usage_error(str(exc))
+        command = _extract_tool_call_command(argv) or "session"
+        envelope, exit_code = _usage_error(str(exc), command=command)
         _attach_feedback_url(envelope)
         print(envelope.model_dump_json())
         return exit_code
@@ -917,17 +925,18 @@ async def _send_session_request(
     args: argparse.Namespace,
     request: ToolCallRequest,
 ) -> tuple[ToolCallEnvelope, int]:
+    public_command = public_command_name(request.command)
     session_id = getattr(args, "session", None)
     if not session_id:
-        return _usage_error("`--session` is required.")
+        return _usage_error("`--session` is required.", command=public_command)
 
     metadata = load_session_metadata(session_id)
     if metadata is None or not is_process_alive(metadata.pid):
-        return _missing_session(session_id)
+        return _missing_session(session_id, command=public_command)
 
     socket_path = get_socket_path(session_id)
     if not socket_path.exists():
-        return _missing_session(session_id)
+        return _missing_session(session_id, command=public_command)
 
     try:
         envelope = await send_request(socket_path, request)
@@ -978,10 +987,13 @@ def _startup_response_from_metadata(metadata: object) -> str:
     return "Session started with desktop backend."
 
 
-def _missing_session(session_id: str) -> tuple[ToolCallEnvelope, int]:
+def _missing_session(
+    session_id: str,
+    command: str = "session",
+) -> tuple[ToolCallEnvelope, int]:
     envelope = make_envelope(
         session_id=session_id,
-        command="session",
+        command=command,
         status=CommandStatus.ERROR,
         response=f"No active session found for {session_id}.",
         screenshot_path=None,
@@ -992,10 +1004,13 @@ def _missing_session(session_id: str) -> tuple[ToolCallEnvelope, int]:
     return envelope, 3
 
 
-def _usage_error(message: str) -> tuple[ToolCallEnvelope, int]:
+def _usage_error(
+    message: str,
+    command: str = "session",
+) -> tuple[ToolCallEnvelope, int]:
     envelope = make_envelope(
         session_id=None,
-        command="session",
+        command=command,
         status=CommandStatus.ERROR,
         response=message,
         screenshot_path=None,

--- a/haindy/tool_call_mode/cli.py
+++ b/haindy/tool_call_mode/cli.py
@@ -13,6 +13,7 @@ from typing import Any, NoReturn
 from uuid import uuid4
 
 from haindy.config.settings import get_settings
+from haindy.feedback import build_issue_url
 from haindy.runtime.environment import normalize_automation_backend
 
 from .daemon import run_daemon_from_args
@@ -618,7 +619,21 @@ async def dispatch_tool_call_args(
     else:  # pragma: no cover - parser guarantees this branch is unreachable
         envelope, exit_code = _usage_error("Unknown tool-call command.")
 
+    _attach_feedback_url(envelope)
     return envelope, exit_code
+
+
+def _attach_feedback_url(envelope: ToolCallEnvelope) -> None:
+    """Populate ``feedback_url`` on failed envelopes. Happy paths stay lean."""
+
+    if envelope.status == CommandStatus.SUCCESS:
+        return
+    envelope.feedback_url = build_issue_url(
+        command=envelope.command,
+        run_id=envelope.run_id,
+        exit_reason=envelope.meta.exit_reason.value,
+        error=envelope.response,
+    )
 
 
 async def run_tool_call_cli(argv: list[str]) -> int:
@@ -629,6 +644,7 @@ async def run_tool_call_cli(argv: list[str]) -> int:
         args = parser.parse_args(argv)
     except ToolCallUsageError as exc:
         envelope, exit_code = _usage_error(str(exc))
+        _attach_feedback_url(envelope)
         print(envelope.model_dump_json())
         return exit_code
 

--- a/haindy/tool_call_mode/models.py
+++ b/haindy/tool_call_mode/models.py
@@ -121,6 +121,7 @@ class ToolCallEnvelope(BaseModel):
     observations: list[str] | None = None
     sessions: list[SessionListEntry] | None = None
     vars: dict[str, str] | None = None
+    feedback_url: str | None = None
 
 
 class ToolCallRequest(BaseModel):

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,98 @@
+"""Tests for the feedback URL helper."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from haindy import feedback
+from haindy.feedback import (
+    ISSUE_URL_BASE,
+    MAX_ERROR_SNIPPET_CHARS,
+    OPT_OUT_ENV_VAR,
+    build_issue_url,
+    console_feedback_hint,
+    feedback_enabled,
+)
+
+
+def test_build_issue_url_contains_expected_fields() -> None:
+    url = build_issue_url(
+        command="act",
+        run_id="run-123",
+        exit_reason="element_not_found",
+        error="Could not locate the Submit button",
+    )
+    assert url is not None
+    parsed = urlparse(url)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == ISSUE_URL_BASE
+
+    params = parse_qs(parsed.query)
+    title = params["title"][0]
+    body = params["body"][0]
+    labels = params["labels"][0]
+
+    assert "act" in title
+    assert "element_not_found" in title
+    assert labels == "user-feedback"
+
+    assert "**Command:** `haindy act`" in body
+    assert "**Run ID:** run-123" in body
+    assert "**Exit reason:** element_not_found" in body
+    assert "Could not locate the Submit button" in body
+    assert "**HAINDY version:**" in body
+    assert "**Platform:**" in body
+    assert "**Python:**" in body
+
+
+def test_build_issue_url_none_context() -> None:
+    url = build_issue_url(command="run")
+    assert url is not None
+    body = parse_qs(urlparse(url).query)["body"][0]
+    assert "**Run ID:** n/a" in body
+    assert "**Exit reason:** n/a" in body
+    assert "_(none)_" in body
+
+
+def test_build_issue_url_truncates_long_error() -> None:
+    huge = "x" * 20000
+    url = build_issue_url(
+        command="explore",
+        run_id="r",
+        exit_reason="stuck",
+        error=huge,
+    )
+    assert url is not None
+    body = parse_qs(urlparse(url).query)["body"][0]
+    assert "[truncated]" in body
+    assert len(body) < feedback.MAX_BODY_CHARS + 50
+    assert len(url) < 9000  # well under GitHub's ~8KB URL limit + scheme/path
+
+
+def test_error_snippet_truncation_threshold() -> None:
+    exact = "y" * (MAX_ERROR_SNIPPET_CHARS + 500)
+    url = build_issue_url(command="run", error=exact)
+    assert url is not None
+    body = parse_qs(urlparse(url).query)["body"][0]
+    assert "[truncated]" in body
+
+
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_opt_out_env_var_disables_url(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(OPT_OUT_ENV_VAR, value)
+    assert feedback_enabled() is False
+    assert build_issue_url(command="run") is None
+
+
+def test_opt_out_default_is_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OPT_OUT_ENV_VAR, raising=False)
+    assert feedback_enabled() is True
+    assert build_issue_url(command="run") is not None
+
+
+def test_console_feedback_hint_contains_url() -> None:
+    url = "https://example.com/issues/new"
+    hint = console_feedback_hint(url)
+    assert url in hint
+    assert "feedback" in hint.lower() or "bug" in hint.lower()

--- a/tests/test_tool_call_envelope_feedback.py
+++ b/tests/test_tool_call_envelope_feedback.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from haindy.feedback import OPT_OUT_ENV_VAR
-from haindy.tool_call_mode.cli import _attach_feedback_url
+from haindy.tool_call_mode.cli import _attach_feedback_url, run_tool_call_cli
 from haindy.tool_call_mode.models import (
     CommandStatus,
     ExitReason,
@@ -58,3 +60,25 @@ def test_opt_out_suppresses_feedback_url(monkeypatch: pytest.MonkeyPatch) -> Non
     )
     _attach_feedback_url(env)
     assert env.feedback_url is None
+
+
+@pytest.mark.asyncio
+async def test_missing_session_envelope_reports_actual_command(capsys) -> None:
+    exit_code = await run_tool_call_cli(
+        ["--session", "does-not-exist-xyz", "act", "click submit"]
+    )
+    assert exit_code == 3
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "act"
+    assert payload["status"] == "error"
+    assert payload["feedback_url"] is not None
+
+
+@pytest.mark.asyncio
+async def test_usage_error_envelope_reports_actual_command(capsys) -> None:
+    exit_code = await run_tool_call_cli(["test"])
+    assert exit_code == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "test"

--- a/tests/test_tool_call_envelope_feedback.py
+++ b/tests/test_tool_call_envelope_feedback.py
@@ -1,0 +1,60 @@
+"""Tests for feedback URL injection on tool-call envelopes."""
+
+from __future__ import annotations
+
+import pytest
+
+from haindy.feedback import OPT_OUT_ENV_VAR
+from haindy.tool_call_mode.cli import _attach_feedback_url
+from haindy.tool_call_mode.models import (
+    CommandStatus,
+    ExitReason,
+    make_envelope,
+)
+
+
+def _envelope(*, status: CommandStatus, exit_reason: ExitReason):
+    return make_envelope(
+        session_id="sess-1",
+        run_id="run-42",
+        command="act",
+        status=status,
+        response="Click intended element but nothing happened",
+        screenshot_path=None,
+        exit_reason=exit_reason,
+        duration_ms=10,
+        actions_taken=1,
+    )
+
+
+def test_success_envelope_has_no_feedback_url() -> None:
+    env = _envelope(status=CommandStatus.SUCCESS, exit_reason=ExitReason.COMPLETED)
+    _attach_feedback_url(env)
+    assert env.feedback_url is None
+
+
+def test_failure_envelope_populates_feedback_url() -> None:
+    env = _envelope(
+        status=CommandStatus.FAILURE,
+        exit_reason=ExitReason.ELEMENT_NOT_FOUND,
+    )
+    _attach_feedback_url(env)
+    assert env.feedback_url is not None
+    assert "github.com/Haindy/haindy/issues/new" in env.feedback_url
+    assert "element_not_found" in env.feedback_url
+
+
+def test_error_envelope_populates_feedback_url() -> None:
+    env = _envelope(status=CommandStatus.ERROR, exit_reason=ExitReason.AGENT_ERROR)
+    _attach_feedback_url(env)
+    assert env.feedback_url is not None
+
+
+def test_opt_out_suppresses_feedback_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(OPT_OUT_ENV_VAR, "1")
+    env = _envelope(
+        status=CommandStatus.FAILURE,
+        exit_reason=ExitReason.ELEMENT_NOT_FOUND,
+    )
+    _attach_feedback_url(env)
+    assert env.feedback_url is None

--- a/tests/test_tool_call_mode_cli.py
+++ b/tests/test_tool_call_mode_cli.py
@@ -198,7 +198,7 @@ async def test_run_tool_call_cli_returns_json_usage_envelope_on_bad_args(
 
     assert exit_code == 2
     assert payload["status"] == "error"
-    assert payload["command"] == "session"
+    assert payload["command"] == "act"
     assert (
         "`--session` is required." in payload["response"]
         or "required" in payload["response"]


### PR DESCRIPTION
## Summary

- New `haindy/feedback.py` builds `github.com/Haindy/haindy/issues/new` URLs with title and body pre-filled from run context (version, platform, Python, command, run id, exit reason, truncated error snippet). No outbound telemetry — the user reviews and submits on github.com.
- Batch mode (`haindy run`) prints a one-line hint at end-of-run and on error paths (scope blocked, timeout, generic exception).
- Tool-call mode adds an optional `feedback_url` field to `ToolCallEnvelope`, populated only on non-success responses so AI coding agents surface the link when relaying failures to the user.
- Error envelopes now report the actual command (`act`, `test`, `explore`, `screenshot`, ...) instead of always `"session"`. Affects both the `command` field and the feedback URL title.
- Opt-out via `HAINDY_NO_FEEDBACK_URL=1`.

Design: [docs/design/FEEDBACK.md](docs/design/FEEDBACK.md)

## Test plan
- [x] `ruff check` clean on all changed files
- [x] `pytest tests/test_feedback.py tests/test_tool_call_envelope_feedback.py tests/test_tool_call_mode_cli.py tests/test_main.py` — 67 pass
- [x] Manual: `haindy act` (argparse usage error) → JSON envelope carries `feedback_url` with `command: act`
- [x] Manual: `haindy --session bogus act "click"` (missing session) → JSON envelope carries `feedback_url` with `command: act`
- [x] Manual: `HAINDY_NO_FEEDBACK_URL=1 haindy act` → `feedback_url: null`
- [x] Manual: end-to-end batch failure prints the hint line (not re-verified after the envelope-command fix — unchanged path)