### PR TITLE
Format feedback module to satisfy ruff format

### DIFF
--- a/haindy/feedback.py
+++ b/haindy/feedback.py
@@ -57,8 +57,12 @@ def _render_body(
     exit_reason: str | None,
     error: str | None,
 ) -> str:
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-    error_block = _truncate(error.strip(), MAX_ERROR_SNIPPET_CHARS) if error else "_(none)_"
+    python_version = (
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    )
+    error_block = (
+        _truncate(error.strip(), MAX_ERROR_SNIPPET_CHARS) if error else "_(none)_"
+    )
 
     body = (
         "<!-- Pre-filled by HAINDY. Edit freely before submitting. -->\n"

--- a/haindy/main.py
+++ b/haindy/main.py
@@ -322,7 +322,9 @@ async def run_test(
             command="run",
             run_id=test_run_id,
             exit_reason=str(status_value),
-            error=None if status_value in success_statuses else f"Status: {status_value}",
+            error=None
+            if status_value in success_statuses
+            else f"Status: {status_value}",
         )
 
         return 0 if status_value in success_statuses else 1

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -79,7 +79,9 @@ def test_error_snippet_truncation_threshold() -> None:
 
 
 @pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
-def test_opt_out_env_var_disables_url(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+def test_opt_out_env_var_disables_url(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
     monkeypatch.setenv(OPT_OUT_ENV_VAR, value)
     assert feedback_enabled() is False
     assert build_issue_url(command="run") is None


### PR DESCRIPTION
## Summary

- Ran `ruff format` on the three files introduced in #115 (`haindy/feedback.py`, `haindy/main.py`, `tests/test_feedback.py`)
- Pure line-wrapping changes — no logic touched
- My miss in #115: I ran `ruff check` but not `ruff format --check`, so formatter violations landed on main

## Test plan
- [x] `ruff format --check .` — clean
- [x] `ruff check .` — clean
- [x] `pytest tests/test_feedback.py tests/test_tool_call_envelope_feedback.py` — 16 pass