### PR TITLE
Fix DUK-58 Node 24 GitHub Actions pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -22,8 +22,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -36,8 +36,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -31,7 +31,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -43,8 +43,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,9 @@ cython_debug/
 # VS Code
 .vscode/
 
+# Local Codex settings
+.codex/config.toml
+
 # macOS
 .DS_Store
 


### PR DESCRIPTION
## Summary

- Update the release workflow GitHub-owned actions to Node 24-compatible major tags.
- Update CI checkout/setup-python pins to the same Node 24-compatible majors to avoid the same warnings outside release.
- Ignore local `.codex/config.toml` while keeping shared `.codex/skills` tracked.

## Why

GitHub Actions warned that the release workflow still referenced actions backed by Node.js 20. This keeps the tag-driven release flow ahead of the Node 24 cutoff while using floating major tags for reviewable updates.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format .`
- `.venv/bin/mypy haindy`
- `.venv/bin/pytest` (`745 passed, 4 skipped`)

Fixes DUK-58.