### PR TITLE
[codex] Unify data artifacts under HAINDY home

### DIFF
--- a/.agents/skills/haindy-setup/SKILL.md
+++ b/.agents/skills/haindy-setup/SKILL.md
@@ -71,6 +71,12 @@ Key sections:
 | `storage` | `data_dir`, `reports_dir`, `cache_dir` |
 | `cache` | `enable_planning`, `enable_situational`, `enable_execution_replay` |
 
+Storage note: if `storage.data_dir` is unset, data artifacts go under
+`~/.haindy/data/projects/<project-id>/`, where the project id is derived from
+the resolved current working directory. Setting `storage.data_dir` or
+`HAINDY_DATA_DIR` uses that exact root. Old `.env` path overrides like
+`HAINDY_DATA_DIR=data` keep writing to `./data` until removed.
+
 ## Step 4 — Verify the effective configuration
 
 ```bash

--- a/.codex/skills/haindy-test-forensics/SKILL.md
+++ b/.codex/skills/haindy-test-forensics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: haindy-test-forensics
-description: Investigate failed HAINDY runtime test executions by reconstructing the sequence of events from `data/traces/*.json`, `data/model_logs/model_calls.jsonl`, screenshots, and `reports/run-id/` artifacts, then explain what happened and suggest fixes. Use when a user asks for forensics on the last or a specific HAINDY run, wants a high-level failure timeline, issue analysis, or candidate fixes from repo-local artifacts in `data/`. Do not use this skill for ordinary `pytest` stack-trace debugging.
+description: Investigate failed HAINDY runtime test executions by reconstructing the sequence of events from `<data-root>/traces/*.json`, `<data-root>/model_logs/model_calls.jsonl`, screenshots, and `reports/run-id/` artifacts, then explain what happened and suggest fixes. Use when a user asks for forensics on the last or a specific HAINDY run, wants a high-level failure timeline, issue analysis, or candidate fixes from local HAINDY data artifacts. Do not use this skill for ordinary `pytest` stack-trace debugging.
 ---
 
 # Haindy Test Forensics
@@ -8,7 +8,9 @@ description: Investigate failed HAINDY runtime test executions by reconstructing
 ## Overview
 
 Analyze a failed HAINDY execution run from local artifacts and explain it in plain English.
-Prioritize `data/` artifacts, reconstruct the run sequence, identify the most likely failure category, and propose fixes without inventing non-visual root causes.
+Prioritize artifacts under the effective HAINDY data root, reconstruct the run sequence, identify the most likely failure category, and propose fixes without inventing non-visual root causes.
+
+By default, the data root is `~/.haindy/data/projects/<project-id>` for the resolved current working directory. `HAINDY_DATA_DIR` or `storage.data_dir` overrides it exactly. If a user has old copied env vars pointing at `data/...`, artifacts may still be under `./data` until those overrides are removed.
 
 ## Guardrails
 
@@ -26,20 +28,20 @@ Prioritize `data/` artifacts, reconstruct the run sequence, identify the most li
 
 Read artifacts in this order unless the user points you somewhere else:
 
-1. `data/traces/<run_id>.json`
+1. `<data-root>/traces/<run_id>.json`
 This is the authoritative run timeline: backend, start/end times, step ordering, pass/fail status, expected vs actual results, and before/after screenshot paths.
 
 2. `reports/<run_id>/*-actions.json`
 Use this for per-action detail: interpreted action type, prompts, automation calls, verification summaries, and bug-report payloads.
 
-3. `data/model_logs/model_calls.jsonl`
+3. `<data-root>/model_logs/model_calls.jsonl`
 Filter by `run_id` to inspect planner/interpreter/executor/verifier reasoning, prompt text, and screenshot attachments.
 
-4. `data/model_logs/screenshots/`
+4. `<data-root>/model_logs/screenshots/`
 Use these as visual evidence referenced by model logs. They are often the best way to confirm what the CU model actually saw.
 
 5. `debug_screenshots/<run_id>/`
-Use these when the trace or action JSON points to step-level before/after screenshots outside `data/`.
+Use these when the trace or action JSON points to step-level before/after screenshots outside the data root.
 
 6. `reports/<run_id>/*.html`
 Treat the HTML report as a convenience view, not the source of truth.
@@ -81,7 +83,7 @@ Look for:
 Typical command:
 
 ```bash
-rg -n "\"run_id\": \"<run_id>\"" data/model_logs/model_calls.jsonl
+rg -n "\"run_id\": \"<run_id>\"" <data-root>/model_logs/model_calls.jsonl
 ```
 
 5. Check the screenshots tied to the failing step.
@@ -130,6 +132,6 @@ Do not overstate confidence.
 ## Example Trigger Phrases
 
 - `The last test run failed. I need you to do forensics and tell me what happened.`
-- `Analyze the latest failed HAINDY run from data/.`
+- `Analyze the latest failed HAINDY run from the data root.`
 - `Do forensics on run 20260313T144056Z_447777a8 and suggest fixes.`
 - `Explain the sequence of events and root cause for the last mobile_adb failure.`

--- a/.codex/skills/haindy-test-forensics/agents/openai.yaml
+++ b/.codex/skills/haindy-test-forensics/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Haindy Test Forensics"
-  short_description: "Forensics for failed Haindy runs from data artifacts"
-  default_prompt: "Use $haindy-test-forensics to investigate the last failed HAINDY test run, reconstruct the high-level sequence of events, explain the issue, and propose likely fixes from the run artifacts in data/."
+  short_description: "Forensics for failed Haindy runs from local data artifacts"
+  default_prompt: "Use $haindy-test-forensics to investigate the last failed HAINDY test run, reconstruct the high-level sequence of events, explain the issue, and propose likely fixes from the run artifacts in the effective HAINDY data root."

--- a/.codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py
+++ b/.codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py
@@ -9,32 +9,50 @@ import sys
 from pathlib import Path
 from typing import Any
 
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[4]
+    return _REPO_ROOT
 
 
 def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _trace_files(repo_root: Path) -> list[Path]:
-    trace_dir = repo_root / "data" / "traces"
+def _data_root() -> Path:
+    from haindy.config.settings import load_settings
+
+    return load_settings().data_dir
+
+
+def _display_path(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+def _trace_files(data_root: Path) -> list[Path]:
+    trace_dir = data_root / "traces"
     return sorted(trace_dir.glob("*.json"))
 
 
 def _select_trace(
-    repo_root: Path,
+    data_root: Path,
     run_id: str | None,
     latest: bool,
     latest_failed: bool,
 ) -> Path:
-    traces = _trace_files(repo_root)
+    trace_dir = data_root / "traces"
+    traces = _trace_files(data_root)
     if not traces:
-        raise FileNotFoundError("No trace files found under data/traces")
+        raise FileNotFoundError(f"No trace files found under {trace_dir}")
 
     if run_id:
-        candidate = repo_root / "data" / "traces" / f"{run_id}.json"
+        candidate = trace_dir / f"{run_id}.json"
         if not candidate.exists():
             raise FileNotFoundError(f"Trace for run_id {run_id!r} not found")
         return candidate
@@ -47,7 +65,7 @@ def _select_trace(
         if latest_failed and not bool(trace.get("success")):
             return trace_path
 
-    raise FileNotFoundError("No failed trace files found under data/traces")
+    raise FileNotFoundError(f"No failed trace files found under {trace_dir}")
 
 
 def _failed_steps(trace: dict[str, Any]) -> list[dict[str, Any]]:
@@ -71,7 +89,7 @@ def _failed_steps(trace: dict[str, Any]) -> list[dict[str, Any]]:
     return failed
 
 
-def _summarize(trace_path: Path, repo_root: Path) -> dict[str, Any]:
+def _summarize(trace_path: Path, repo_root: Path, data_root: Path) -> dict[str, Any]:
     trace = _load_json(trace_path)
     run_id = str(trace.get("run_id") or trace_path.stem)
     report_dir = repo_root / "reports" / run_id
@@ -92,13 +110,14 @@ def _summarize(trace_path: Path, repo_root: Path) -> dict[str, Any]:
     passed_steps = sum(1 for status in statuses if status == "passed")
     failed_steps = _failed_steps(trace)
 
-    model_log_path = (
-        (trace.get("run_metadata") or {}).get("model_log_path")
-    ) or "data/model_logs/model_calls.jsonl"
+    model_log_path = ((trace.get("run_metadata") or {}).get("model_log_path")) or str(
+        data_root / "model_logs" / "model_calls.jsonl"
+    )
 
     return {
         "run_id": run_id,
-        "trace_path": str(trace_path.relative_to(repo_root)),
+        "data_root": str(data_root),
+        "trace_path": _display_path(trace_path, repo_root),
         "success": bool(trace.get("success")),
         "started_at": trace.get("started_at"),
         "ended_at": trace.get("ended_at"),
@@ -141,11 +160,12 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = _repo_root()
+    data_root = _data_root()
     latest_failed = args.latest_failed or (not args.run_id and not args.latest)
 
     try:
         trace_path = _select_trace(
-            repo_root=repo_root,
+            data_root=data_root,
             run_id=args.run_id,
             latest=args.latest,
             latest_failed=latest_failed,
@@ -154,7 +174,7 @@ def main() -> int:
         print(str(exc), file=sys.stderr)
         return 1
 
-    summary = _summarize(trace_path, repo_root)
+    summary = _summarize(trace_path, repo_root, data_root)
     print(json.dumps(summary, indent=2))
     return 0
 

--- a/.env.example
+++ b/.env.example
@@ -43,29 +43,36 @@ HAINDY_SCREENSHOT_QUALITY=80
 
 # File and cache paths
 HAINDY_HOME=~/.haindy
-HAINDY_DATA_DIR=data
+# By default, data artifacts are written under:
+#   HAINDY_HOME/data/projects/<project-id>/
+# where <project-id> is based on the resolved current working directory.
+# Uncomment HAINDY_DATA_DIR to use an exact custom data root. Legacy copied
+# values like `data` continue to write to ./data until the override is removed.
+# HAINDY_DATA_DIR=/absolute/path/to/haindy-data
 HAINDY_REPORTS_DIR=reports
-HAINDY_SCREENSHOTS_DIR=data/screenshots
+# Specific data-family path overrides below are intentionally commented out.
+# If set, they win over HAINDY_DATA_DIR and the project-scoped defaults.
+# HAINDY_SCREENSHOTS_DIR=/absolute/path/to/haindy-data/screenshots
 HAINDY_CACHE_DIR=.cache
-HAINDY_TASK_PLAN_CACHE_PATH=data/task_plan_cache.json
-HAINDY_PLANNING_CACHE_PATH=data/planning_cache.json
-HAINDY_SITUATIONAL_CACHE_PATH=data/situational_cache.json
-HAINDY_EXECUTION_REPLAY_CACHE_PATH=data/execution_replay_cache.json
-HAINDY_LINUX_COORDINATE_CACHE_PATH=data/linux_cache/coordinates.json
-HAINDY_WINDOWS_COORDINATE_CACHE_PATH=data/windows_cache/coordinates.json
-HAINDY_WINDOWS_SCREENSHOT_DIR=data/screenshots/windows
+# HAINDY_TASK_PLAN_CACHE_PATH=/absolute/path/to/haindy-data/task_plan_cache.json
+# HAINDY_PLANNING_CACHE_PATH=/absolute/path/to/haindy-data/planning_cache.json
+# HAINDY_SITUATIONAL_CACHE_PATH=/absolute/path/to/haindy-data/situational_cache.json
+# HAINDY_EXECUTION_REPLAY_CACHE_PATH=/absolute/path/to/haindy-data/execution_replay_cache.json
+# HAINDY_LINUX_COORDINATE_CACHE_PATH=/absolute/path/to/haindy-data/linux_cache/coordinates.json
+# HAINDY_WINDOWS_COORDINATE_CACHE_PATH=/absolute/path/to/haindy-data/windows_cache/coordinates.json
+# HAINDY_WINDOWS_SCREENSHOT_DIR=/absolute/path/to/haindy-data/screenshots/windows
 HAINDY_WINDOWS_KEYBOARD_LAYOUT=us
 HAINDY_WINDOWS_KEY_DELAY_MS=12
 HAINDY_WINDOWS_CLIPBOARD_TIMEOUT_SECONDS=3.0
 HAINDY_WINDOWS_CLIPBOARD_HOLD_SECONDS=15.0
-HAINDY_DESKTOP_SCREENSHOT_DIR=data/screenshots/desktop
+# HAINDY_DESKTOP_SCREENSHOT_DIR=/absolute/path/to/haindy-data/screenshots/desktop
 HAINDY_MAX_SCREENSHOTS=12
 
 # Logging
 HAINDY_LOG_LEVEL=INFO
 HAINDY_LOG_FORMAT=text
 HAINDY_LOG_FILE=
-HAINDY_MODEL_LOG_PATH=data/model_logs/model_calls.jsonl
+# HAINDY_MODEL_LOG_PATH=/absolute/path/to/haindy-data/model_logs/model_calls.jsonl
 
 # Desktop automation
 HAINDY_AUTOMATION_BACKEND=desktop
@@ -87,14 +94,14 @@ HAINDY_DESKTOP_CLIPBOARD_TIMEOUT_SECONDS=3.0
 HAINDY_DESKTOP_CLIPBOARD_HOLD_SECONDS=15.0
 
 # Mobile automation (ADB / Android)
-HAINDY_MOBILE_SCREENSHOT_DIR=data/screenshots/mobile
-HAINDY_MOBILE_COORDINATE_CACHE_PATH=data/mobile_cache/coordinates.json
+# HAINDY_MOBILE_SCREENSHOT_DIR=/absolute/path/to/haindy-data/screenshots/mobile
+# HAINDY_MOBILE_COORDINATE_CACHE_PATH=/absolute/path/to/haindy-data/mobile_cache/coordinates.json
 HAINDY_MOBILE_DEFAULT_ADB_SERIAL=
 HAINDY_MOBILE_ADB_TIMEOUT_SECONDS=15.0
 
 # iOS automation (idb)
-HAINDY_IOS_SCREENSHOT_DIR=data/screenshots/ios
-HAINDY_IOS_COORDINATE_CACHE_PATH=data/ios_cache/coordinates.json
+# HAINDY_IOS_SCREENSHOT_DIR=/absolute/path/to/haindy-data/screenshots/ios
+# HAINDY_IOS_COORDINATE_CACHE_PATH=/absolute/path/to/haindy-data/ios_cache/coordinates.json
 HAINDY_IOS_DEFAULT_DEVICE_UDID=
 HAINDY_IOS_IDB_TIMEOUT_SECONDS=15.0
 
@@ -102,8 +109,8 @@ HAINDY_IOS_IDB_TIMEOUT_SECONDS=15.0
 # Requires Accessibility permission for keyboard injection and
 # Screen Recording permission for screenshot capture.
 # Grant both in System Settings -> Privacy & Security.
-HAINDY_MACOS_SCREENSHOT_DIR=data/screenshots/macos
-HAINDY_MACOS_COORDINATE_CACHE_PATH=data/macos_cache/coordinates.json
+# HAINDY_MACOS_SCREENSHOT_DIR=/absolute/path/to/haindy-data/screenshots/macos
+# HAINDY_MACOS_COORDINATE_CACHE_PATH=/absolute/path/to/haindy-data/macos_cache/coordinates.json
 HAINDY_MACOS_KEYBOARD_LAYOUT=us
 HAINDY_MACOS_KEY_DELAY_MS=12
 HAINDY_MACOS_CLIPBOARD_TIMEOUT_SECONDS=3.0

--- a/.gitignore
+++ b/.gitignore
@@ -186,4 +186,6 @@ secrets/
 docs/prompt.md
 docs/plans/*
 !docs/plans/windows-support.md
+!docs/plans/storage/
+!docs/plans/storage/unify-data-home.md
 docs/issues/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Create `~/.haindy/settings.json` for persistent non-secret configuration:
 
 Environment variables override all other sources. Timeout settings use seconds. In `settings.json`, use `execution.actions_action_timeout_seconds`; the older `execution.actions_action_timeout_ms` key is only accepted as a legacy read-time alias. Linux desktop keyboard layout defaults to `auto`, which detects the active XKB layout and currently supports `us` and `es`; set `desktop.keyboard_layout` explicitly to override detection. See [`.env.example`](.env.example) for the full legacy env-var list.
 
+### Artifact storage
+
+Runtime data artifacts default to `~/.haindy/data/projects/<project-id>/`, where `<project-id>` is derived from the resolved current working directory. This includes traces, model-call logs, screenshots, and replay/coordinate/planning caches. Tool-call session state stays separate under `~/.haindy/sessions/<session-id>/`.
+
+Set `HAINDY_DATA_DIR` or `storage.data_dir` to use an exact custom data root without project scoping. Specific path overrides such as `HAINDY_MODEL_LOG_PATH`, `HAINDY_DESKTOP_SCREENSHOT_DIR`, and `storage.planning_cache_path` still win. If you copied old env vars that point at `data/...`, HAINDY will keep writing to `./data` until those overrides are removed.
+
 ## Platform prerequisites
 
 | Platform | Requirements |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -189,7 +189,8 @@ haindy provider set-model google gemini-3-flash-preview --computer-use
 Important env vars (still supported, override all other sources):
 
 - `HAINDY_AUTOMATION_BACKEND=desktop|mobile_adb|mobile_ios`
-- `HAINDY_HOME` for tool-call session state root
+- `HAINDY_HOME` for HAINDY home storage, defaulting to `~/.haindy`
+- `HAINDY_DATA_DIR` for an exact data-artifact root override
 - `HAINDY_CU_PROVIDER=openai|google|anthropic`
 - `HAINDY_ACTIONS_COMPUTER_TOOL_ACTION_TIMEOUT_SECONDS` for the per-action computer-use timeout budget
 - `HAINDY_OPENAI_API_KEY` for OpenAI API-key auth and OpenAI computer use
@@ -197,6 +198,8 @@ Important env vars (still supported, override all other sources):
 Timeout settings use seconds across the runtime and configuration surface. Use `execution.actions_action_timeout_seconds` in `settings.json`; the older `execution.actions_action_timeout_ms` key is only accepted as a legacy read-time alias for older configs.
 
 Linux desktop keyboard layout defaults to `auto`, which detects the active XKB layout and currently supports `us` and `es`. Set `desktop.keyboard_layout` explicitly when a session should force one of those layouts.
+
+Data artifacts default to `HAINDY_HOME/data/projects/<project-id>/`, where `<project-id>` is derived from the resolved current working directory. Traces, model-call logs, screenshots, replay caches, planning caches, and coordinate caches all derive from that effective data root unless a specific path override is set. If `HAINDY_DATA_DIR` or `storage.data_dir` is set, HAINDY uses that path as the exact data root and does not add project scoping. Users with old copied env vars such as `HAINDY_DATA_DIR=data` or `HAINDY_MODEL_LOG_PATH=data/model_logs/model_calls.jsonl` will keep writing to `./data` until those overrides are removed.
 
 Tool-call mode does not introduce a separate backend env var. Use `HAINDY_AUTOMATION_BACKEND` or explicit `--desktop` / `--android`.
 
@@ -247,12 +250,12 @@ When a background `test` stalls or times out, inspect the session-local forensic
 
 - `~/.haindy/sessions/<SESSION_ID>/session.json` for `latest_background_run_id`, `latest_test_phase`, and `latest_test_action_artifact_path`
 - `~/.haindy/sessions/<SESSION_ID>/action_artifacts/*.json` for per-step action, verification, and status-transition details
-- `data/traces/<RUN_ID>.json` for the run trace tied to the stable background `run_id`
-- `data/model_logs/model_calls.jsonl` for model-call history correlated by that same `run_id`
+- `~/.haindy/data/projects/<project-id>/traces/<RUN_ID>.json` for the run trace tied to the stable background `run_id`
+- `~/.haindy/data/projects/<project-id>/model_logs/model_calls.jsonl` for model-call history correlated by that same `run_id`
 
 ## Model-call artifacts
 
-Durable model-call logs are written to `data/model_logs/model_calls.jsonl`.
+Durable model-call logs are written to `<data-root>/model_logs/model_calls.jsonl`.
 Entries include both successful calls and non-rate-limit failed attempts across
 standard mode and computer-use flows.
 
@@ -261,7 +264,7 @@ entries. This includes HTTP `429`, `resource_exhausted`, and equivalent provider
 signals. Related runtime logger output and retry handling still occur normally.
 
 When a logged call includes attached screenshots, the image files are stored
-under `data/model_logs/screenshots/`.
+under `<data-root>/model_logs/screenshots/`.
 
 ## Troubleshooting
 

--- a/docs/design/tool-call-mode/CLI_SPEC.md
+++ b/docs/design/tool-call-mode/CLI_SPEC.md
@@ -745,7 +745,8 @@ haindy session prune --older-than <days>
 
 | Variable | Description |
 |---|---|
-| `HAINDY_HOME` | Override the base directory (default: `~/.haindy`). Useful in CI. |
+| `HAINDY_HOME` | Override the base directory (default: `~/.haindy`). Session state stays under `HAINDY_HOME/sessions`. |
+| `HAINDY_DATA_DIR` | Override the data artifact root exactly. If unset, traces, model logs, screenshots, and caches use `HAINDY_HOME/data/projects/<project-id>`. |
 | `HAINDY_AUTOMATION_BACKEND` | Default backend for new sessions: `desktop`, `mobile_adb`, or `mobile_ios`. Overridden by `--android`/`--ios`/`--desktop`. |
 
 ---

--- a/docs/design/tool-call-mode/SESSION_DAEMON.md
+++ b/docs/design/tool-call-mode/SESSION_DAEMON.md
@@ -363,7 +363,7 @@ This is an operational fallback, not the primary launch path.
 
 Session directories are not automatically deleted after close. They serve as an audit trail. Use `haindy session prune --older-than <days>` to clean up old sessions (see CLI_SPEC.md).
 
-For background-test triage, `session.json` exposes the latest `run_id`, phase, and action-artifact path so investigators can jump directly into the session-local forensic trail. The session directory is designed to be self-sufficient when combined with `data/traces/<run_id>.json` and `data/model_logs/model_calls.jsonl`.
+For background-test triage, `session.json` exposes the latest `run_id`, phase, and action-artifact path so investigators can jump directly into the session-local forensic trail. The session directory is designed to be self-sufficient when combined with `<data-root>/traces/<run_id>.json` and `<data-root>/model_logs/model_calls.jsonl`, where `<data-root>` defaults to `~/.haindy/data/projects/<project-id>` unless `HAINDY_DATA_DIR` or `storage.data_dir` overrides it.
 
 ---
 

--- a/docs/design/tool-call-mode/SKILL_SPEC.md
+++ b/docs/design/tool-call-mode/SKILL_SPEC.md
@@ -212,7 +212,7 @@ Note: `explore` is driven by an Awareness Agent that maintains the TODO list and
 
 **Screenshots:** The dispatch response for `test` and `explore` includes a `screenshot_path` capturing the device state at the moment the command was accepted. Status poll responses include the latest screenshot from the background task. Haindy's screenshot timing may not match the exact moment you need. Use `haindy screenshot --session <SESSION_ID>` to take your own screenshot at a time you choose.
 
-**Forensics:** When a background `test` stalls or times out, inspect `test-status.phase`, `test-status.last_model_agent`, and `test-status.latest_action_artifact_path` first. Then jump to `~/.haindy/sessions/<SESSION_ID>/session.json`, `~/.haindy/sessions/<SESSION_ID>/action_artifacts/*.json`, `data/traces/<RUN_ID>.json`, and `data/model_logs/model_calls.jsonl`.
+**Forensics:** When a background `test` stalls or times out, inspect `test-status.phase`, `test-status.last_model_agent`, and `test-status.latest_action_artifact_path` first. Then jump to `~/.haindy/sessions/<SESSION_ID>/session.json`, `~/.haindy/sessions/<SESSION_ID>/action_artifacts/*.json`, `<data-root>/traces/<RUN_ID>.json`, and `<data-root>/model_logs/model_calls.jsonl`. By default, `<data-root>` is `~/.haindy/data/projects/<project-id>` for the current working directory; `HAINDY_DATA_DIR` or `storage.data_dir` can override it exactly.
 
 ### 7. Session Variables
 

--- a/docs/plans/storage/unify-data-home.md
+++ b/docs/plans/storage/unify-data-home.md
@@ -1,0 +1,40 @@
+# Unify HAINDY Data Artifacts Under `~/.haindy/data`
+
+## Summary
+
+- Move default data-family artifact, cache, and log paths out of the invocation directory and into `HAINDY_HOME/data/projects/<project-id>/...`.
+- Keep live tool-call session state under `HAINDY_HOME/sessions/<session-id>/...`.
+- Do not automatically move or copy an existing `./data` directory; explicit legacy path overrides continue to work.
+
+## Public Behavior
+
+- `HAINDY_HOME` defaults to `~/.haindy`.
+- The default data root becomes `HAINDY_HOME/data/projects/<project-id>`.
+- `<project-id>` is deterministic from the resolved current working directory and formatted as `<sanitized-cwd-basename>-<sha256[:12]>`.
+- `HAINDY_DATA_DIR` or `storage.data_dir` is an exact root override; project scoping is not added when it is set.
+- Specific path overrides still win over `data_dir`, including `HAINDY_MODEL_LOG_PATH`, `HAINDY_DESKTOP_SCREENSHOT_DIR`, and `storage.planning_cache_path`.
+- `reports_dir`, screen recordings, `debug_screenshots`, and `generated_test_plans` stay unchanged for this first pass.
+
+## Implementation
+
+- Add a small settings helper that computes the project-scoped default data root from `haindy_home` and `Path.cwd().resolve()`.
+- Update unset data-family paths to derive from the effective data root: screenshot directories, model logs, planning/situational/task/execution replay caches, coordinate caches, and platform screenshot directories.
+- Update `RunTraceWriter` so its default trace directory is `get_settings().data_dir / "traces"`.
+- Ensure `Settings.create_directories()` creates all derived data directories, including macOS screenshot output.
+- Preserve tool-call session paths exactly under `HAINDY_HOME/sessions/<session-id>/...`.
+- Update docs and bundled HAINDY skill text so forensic paths point at the effective home data root rather than `./data`.
+
+## Test Plan
+
+- Add settings tests for default project-scoped paths using a temp `HAINDY_HOME` and temp cwd.
+- Add settings tests proving `HAINDY_DATA_DIR` is an exact override and specific path env vars override derived defaults.
+- Update existing config/runtime-environment tests that assert old `data/...` defaults.
+- Add trace tests proving the default trace path follows `settings.data_dir / "traces"` while explicit `trace_dir` remains supported.
+- Add a tool-call path regression test confirming session paths remain under `HAINDY_HOME/sessions`.
+- Run `.venv/bin/ruff check .`, `.venv/bin/ruff format .`, `.venv/bin/mypy haindy`, and `.venv/bin/pytest`.
+
+## Assumptions
+
+- Existing explicit settings or env path overrides are user intent and are preserved.
+- Project-scoped home data avoids cache collisions between unrelated working directories.
+- Users with old copied env vars may keep writing to `./data` until those overrides are removed.

--- a/docs/plans/windows-support.md
+++ b/docs/plans/windows-support.md
@@ -53,7 +53,7 @@ step; Windows driver stubs raise `NotImplementedError`.
   they live).
 - [x] Settings: rename `desktop_coordinate_cache_path` →
   `linux_coordinate_cache_path`; add `windows_coordinate_cache_path` with
-  default `data/windows_cache/coordinates.json`. Legacy JSON key
+  a data-root-derived default. Legacy JSON key
   `desktop.coordinate_cache_path` mapped for back-compat.
 - [x] `haindy/runtime/environment.py`: `sys.platform == "win32"` branches in
   `coordinate_cache_attribute` and `openai_computer_environment`; added
@@ -157,8 +157,7 @@ Done inside a Windows VM on the same branch.
   connectivity.
 - [ ] `.venv\Scripts\haindy run --plan <fixture> --context <fixture>` — full
   scenario against Notepad or Calculator (built-in apps, no third-party
-  prerequisites). Screenshots land in `data/screenshots/`, coordinate cache
-  lands at `data/windows_cache/coordinates.json`.
+  prerequisites). Screenshots and coordinate caches use the effective data root.
 - [ ] Android path: `.venv\Scripts\haindy run --mobile --plan ... --context ...`
   with a USB-connected (or Hyper-V WSA) device — verify ADB dispatch works on
   Windows.

--- a/haindy/config/settings.py
+++ b/haindy/config/settings.py
@@ -2,8 +2,10 @@
 
 import json
 import os
+import re
 from collections.abc import Callable, Mapping
 from functools import lru_cache
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +51,7 @@ DEFAULT_CU_PROVIDER_MODELS: dict[str, str] = {
     "google": "gemini-3-flash-preview",
     "anthropic": "claude-sonnet-4-6",
 }
+PROJECT_ID_HASH_LENGTH = 12
 
 ALLOWED_REASONING_LEVELS: set[str] = {
     "none",
@@ -184,6 +187,57 @@ _CU_PROVIDER_MODEL_FIELDS: dict[str, str] = {
     "google": "google_cu_model",
     "anthropic": "anthropic_cu_model",
 }
+
+
+def build_project_data_id(cwd: Path | None = None) -> str:
+    """Return the stable storage id for a working directory."""
+    resolved = (cwd or Path.cwd()).resolve()
+    raw_name = resolved.name or "project"
+    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", raw_name).strip("._-").lower()
+    digest = sha256(str(resolved).encode("utf-8")).hexdigest()[:PROJECT_ID_HASH_LENGTH]
+    return f"{safe_name or 'project'}-{digest}"
+
+
+def build_project_data_dir(haindy_home: Path, cwd: Path | None = None) -> Path:
+    """Return the default data root for the current project."""
+    return (
+        Path(haindy_home).expanduser()
+        / "data"
+        / "projects"
+        / build_project_data_id(cwd)
+    )
+
+
+def _default_data_dir() -> Path:
+    return build_project_data_dir(Path("~/.haindy").expanduser())
+
+
+def _data_path_defaults(data_dir: Path) -> dict[str, Path]:
+    """Build data-family defaults from the effective data root."""
+    return {
+        "screenshots_dir": data_dir / "screenshots",
+        "desktop_screenshot_dir": data_dir / "screenshots" / "desktop",
+        "mobile_screenshot_dir": data_dir / "screenshots" / "mobile",
+        "ios_screenshot_dir": data_dir / "screenshots" / "ios",
+        "macos_screenshot_dir": data_dir / "screenshots" / "macos",
+        "windows_screenshot_dir": data_dir / "screenshots" / "windows",
+        "linux_coordinate_cache_path": data_dir / "linux_cache" / "coordinates.json",
+        "mobile_coordinate_cache_path": data_dir / "mobile_cache" / "coordinates.json",
+        "ios_coordinate_cache_path": data_dir / "ios_cache" / "coordinates.json",
+        "macos_coordinate_cache_path": data_dir / "macos_cache" / "coordinates.json",
+        "windows_coordinate_cache_path": data_dir
+        / "windows_cache"
+        / "coordinates.json",
+        "task_plan_cache_path": data_dir / "task_plan_cache.json",
+        "planning_cache_path": data_dir / "planning_cache.json",
+        "situational_cache_path": data_dir / "situational_cache.json",
+        "execution_replay_cache_path": data_dir / "execution_replay_cache.json",
+        "model_log_path": data_dir / "model_logs" / "model_calls.jsonl",
+    }
+
+
+def _default_data_path(field_name: str) -> Path:
+    return _data_path_defaults(_default_data_dir())[field_name]
 
 
 def get_default_provider_model(provider: str, *, computer_use: bool = False) -> str:
@@ -458,19 +512,19 @@ class Settings(BaseModel):
         description="Allow resolution downshift for desktop runs",
     )
     desktop_screenshot_dir: Path = Field(
-        default=Path("data/screenshots/desktop"),
+        default_factory=lambda: _default_data_path("desktop_screenshot_dir"),
         description="Directory for desktop screenshots",
     )
     linux_coordinate_cache_path: Path = Field(
-        default=Path("data/linux_cache/coordinates.json"),
+        default_factory=lambda: _default_data_path("linux_coordinate_cache_path"),
         description="Coordinate cache path for Linux desktop actions",
     )
     windows_coordinate_cache_path: Path = Field(
-        default=Path("data/windows_cache/coordinates.json"),
+        default_factory=lambda: _default_data_path("windows_coordinate_cache_path"),
         description="Coordinate cache path for Windows desktop actions",
     )
     task_plan_cache_path: Path = Field(
-        default=Path("data/task_plan_cache.json"),
+        default_factory=lambda: _default_data_path("task_plan_cache_path"),
         description="Task planning cache path",
     )
     enable_planning_cache: bool = Field(
@@ -478,7 +532,7 @@ class Settings(BaseModel):
         description="Enable caching for scope triage and test plan generation",
     )
     planning_cache_path: Path = Field(
-        default=Path("data/planning_cache.json"),
+        default_factory=lambda: _default_data_path("planning_cache_path"),
         description="Scope triage and test planning cache path",
     )
     enable_situational_cache: bool = Field(
@@ -486,7 +540,7 @@ class Settings(BaseModel):
         description="Enable caching for situational execution-context validation",
     )
     situational_cache_path: Path = Field(
-        default=Path("data/situational_cache.json"),
+        default_factory=lambda: _default_data_path("situational_cache_path"),
         description="Situational execution-context cache path",
     )
     enable_execution_replay_cache: bool = Field(
@@ -494,7 +548,7 @@ class Settings(BaseModel):
         description="Enable execution replay cache (record/replay driver actions per step)",
     )
     execution_replay_cache_path: Path = Field(
-        default=Path("data/execution_replay_cache.json"),
+        default_factory=lambda: _default_data_path("execution_replay_cache_path"),
         description="Execution replay cache path",
     )
     desktop_display: str | None = Field(
@@ -512,11 +566,11 @@ class Settings(BaseModel):
         description="Max time to hold clipboard owner process",
     )
     mobile_screenshot_dir: Path = Field(
-        default=Path("data/screenshots/mobile"),
+        default_factory=lambda: _default_data_path("mobile_screenshot_dir"),
         description="Directory for mobile screenshots",
     )
     mobile_coordinate_cache_path: Path = Field(
-        default=Path("data/mobile_cache/coordinates.json"),
+        default_factory=lambda: _default_data_path("mobile_coordinate_cache_path"),
         description="Coordinate cache path for mobile actions",
     )
     mobile_default_adb_serial: str = Field(
@@ -529,11 +583,11 @@ class Settings(BaseModel):
         description="Timeout in seconds for individual ADB commands",
     )
     ios_screenshot_dir: Path = Field(
-        default=Path("data/screenshots/ios"),
+        default_factory=lambda: _default_data_path("ios_screenshot_dir"),
         description="Directory for iOS screenshots",
     )
     ios_coordinate_cache_path: Path = Field(
-        default=Path("data/ios_cache/coordinates.json"),
+        default_factory=lambda: _default_data_path("ios_coordinate_cache_path"),
         description="Coordinate cache path for iOS actions",
     )
     ios_default_device_udid: str = Field(
@@ -546,11 +600,11 @@ class Settings(BaseModel):
         description="Timeout in seconds for individual idb commands",
     )
     macos_screenshot_dir: Path = Field(
-        default=Path("data/screenshots/macos"),
+        default_factory=lambda: _default_data_path("macos_screenshot_dir"),
         description="Directory for macOS desktop screenshots",
     )
     macos_coordinate_cache_path: Path = Field(
-        default=Path("data/macos_cache/coordinates.json"),
+        default_factory=lambda: _default_data_path("macos_coordinate_cache_path"),
         description="Coordinate cache path for macOS desktop actions",
     )
     macos_keyboard_layout: str = Field(
@@ -573,7 +627,7 @@ class Settings(BaseModel):
         description="Max time to hold macOS clipboard owner process",
     )
     windows_screenshot_dir: Path = Field(
-        default=Path("data/screenshots/windows"),
+        default_factory=lambda: _default_data_path("windows_screenshot_dir"),
         description="Directory for Windows desktop screenshots",
     )
     windows_keyboard_layout: str = Field(
@@ -786,7 +840,7 @@ class Settings(BaseModel):
     )
     log_file: str | None = Field(default=None, description="Log file path")
     model_log_path: Path = Field(
-        default=Path("data/model_logs/model_calls.jsonl"),
+        default_factory=lambda: _default_data_path("model_log_path"),
         description="Log file for raw model prompts/responses",
     )
     max_screenshots: int | None = Field(
@@ -796,12 +850,15 @@ class Settings(BaseModel):
     )
 
     # Storage Configuration
-    data_dir: Path = Field(default=Path("data"), description="Data storage directory")
+    data_dir: Path = Field(
+        default_factory=_default_data_dir, description="Data storage directory"
+    )
     reports_dir: Path = Field(
         default=Path("reports"), description="Reports output directory"
     )
     screenshots_dir: Path = Field(
-        default=Path("data/screenshots"), description="Screenshots directory"
+        default_factory=lambda: _default_data_path("screenshots_dir"),
+        description="Screenshots directory",
     )
     cache_dir: Path = Field(default=Path(".cache"), description="Cache directory")
 
@@ -932,6 +989,19 @@ class Settings(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def apply_data_path_defaults(self) -> "Settings":
+        """Derive unset data-family paths from the effective data root."""
+        explicit_fields = set(self.model_fields_set)
+        if "data_dir" not in explicit_fields:
+            self.data_dir = build_project_data_dir(self.haindy_home)
+
+        defaults = _data_path_defaults(self.data_dir)
+        for field_name, path in defaults.items():
+            if field_name not in explicit_fields:
+                setattr(self, field_name, path)
+        return self
+
+    @model_validator(mode="after")
     def apply_computer_use_defaults(self) -> "Settings":
         """Apply provider-specific defaults for computer-use sessions."""
         if self.cu_provider == "google":
@@ -982,6 +1052,7 @@ class Settings(BaseModel):
             self.desktop_screenshot_dir,
             self.mobile_screenshot_dir,
             self.ios_screenshot_dir,
+            self.macos_screenshot_dir,
             self.windows_screenshot_dir,
             self.cache_dir,
             self.haindy_home,
@@ -995,6 +1066,7 @@ class Settings(BaseModel):
             self.situational_cache_path.parent,
             self.execution_replay_cache_path.parent,
             self.model_log_path.parent,
+            self.data_dir / "journals",
             self.screen_recording_output_dir,
         ]:
             dir_path.mkdir(parents=True, exist_ok=True)

--- a/haindy/journal/manager.py
+++ b/haindy/journal/manager.py
@@ -29,6 +29,12 @@ from haindy.monitoring.logger import get_logger
 logger = get_logger(__name__)
 
 
+def _default_journal_dir() -> Path:
+    from haindy.config.settings import get_settings
+
+    return get_settings().data_dir / "journals"
+
+
 class JournalManager:
     """
     Manages execution journals for test runs.
@@ -44,7 +50,7 @@ class JournalManager:
         Args:
             journal_dir: Directory to store journal files
         """
-        self.journal_dir = journal_dir or Path("data/journals")
+        self.journal_dir = journal_dir or _default_journal_dir()
         self.journal_dir.mkdir(parents=True, exist_ok=True)
 
         # Active journals

--- a/haindy/runtime/trace.py
+++ b/haindy/runtime/trace.py
@@ -96,7 +96,7 @@ class RunTraceWriter:
 
     def __init__(self, run_id: str, *, trace_dir: Path | None = None) -> None:
         self.run_id = run_id
-        self._path = (trace_dir or Path("data/traces")) / f"{run_id}.json"
+        self._path = (trace_dir or _default_trace_dir()) / f"{run_id}.json"
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._data: dict[str, Any] = {
             "trace_version": TRACE_VERSION,
@@ -186,3 +186,9 @@ class RunTraceWriter:
             self._path.write_text(serialized, encoding="utf-8")
         except Exception:
             logger.debug("RunTraceWriter: failed to write trace file", exc_info=True)
+
+
+def _default_trace_dir() -> Path:
+    from haindy.config.settings import get_settings
+
+    return get_settings().data_dir / "traces"

--- a/haindy/skills/haindy-setup/SKILL.md
+++ b/haindy/skills/haindy-setup/SKILL.md
@@ -71,6 +71,12 @@ Key sections:
 | `storage` | `data_dir`, `reports_dir`, `cache_dir` |
 | `cache` | `enable_planning`, `enable_situational`, `enable_execution_replay` |
 
+Storage note: if `storage.data_dir` is unset, data artifacts go under
+`~/.haindy/data/projects/<project-id>/`, where the project id is derived from
+the resolved current working directory. Setting `storage.data_dir` or
+`HAINDY_DATA_DIR` uses that exact root. Old `.env` path overrides like
+`HAINDY_DATA_DIR=data` keep writing to `./data` until removed.
+
 ## Step 4 — Verify the effective configuration
 
 ```bash

--- a/tests/support_test_runner.py
+++ b/tests/support_test_runner.py
@@ -115,7 +115,7 @@ class _StubActionAgent:
 class _StubTraceWriter:
     def __init__(self, run_id: str) -> None:
         self.run_id = run_id
-        self.path = Path("data/traces/test_trace.json")
+        self.path = Path("traces/test_trace.json")
 
     def set_run_metadata(self, metadata: dict[str, object]) -> None:
         del metadata

--- a/tests/test_action_agent.py
+++ b/tests/test_action_agent.py
@@ -21,7 +21,7 @@ def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "haindy.agents.action_agent.get_settings",
         lambda: SimpleNamespace(
-            linux_coordinate_cache_path=Path("data/linux_cache/test_coordinates.json"),
+            linux_coordinate_cache_path=Path("tmp/linux_cache/test_coordinates.json"),
             computer_use_model="gpt-5.4",
             cu_provider="openai",
         ),
@@ -151,15 +151,13 @@ def test_new_computer_use_session_skips_openai_client_for_google(
     monkeypatch.setattr(
         "haindy.agents.action_agent.get_settings",
         lambda: SimpleNamespace(
-            linux_coordinate_cache_path=Path("data/linux_cache/test_coordinates.json"),
+            linux_coordinate_cache_path=Path("tmp/linux_cache/test_coordinates.json"),
             windows_coordinate_cache_path=Path(
-                "data/windows_cache/test_coordinates.json"
+                "tmp/windows_cache/test_coordinates.json"
             ),
-            macos_coordinate_cache_path=Path("data/macos_cache/test_coordinates.json"),
-            mobile_coordinate_cache_path=Path(
-                "data/mobile_cache/test_coordinates.json"
-            ),
-            ios_coordinate_cache_path=Path("data/ios_cache/test_coordinates.json"),
+            macos_coordinate_cache_path=Path("tmp/macos_cache/test_coordinates.json"),
+            mobile_coordinate_cache_path=Path("tmp/mobile_cache/test_coordinates.json"),
+            ios_coordinate_cache_path=Path("tmp/ios_cache/test_coordinates.json"),
             computer_use_model="gpt-5.4",
             cu_provider="google",
         ),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for application settings."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ from haindy.config.settings import (
     AgentModelConfig,
     ConfigManager,
     Settings,
+    build_project_data_dir,
     load_settings,
 )
 
@@ -19,8 +21,12 @@ class TestSettings:
         settings = Settings()
         assert settings.desktop_prefer_resolution[0] >= 800
         assert settings.desktop_prefer_resolution[1] >= 600
-        assert settings.desktop_screenshot_dir == Path("data/screenshots/desktop")
-        assert settings.mobile_screenshot_dir == Path("data/screenshots/mobile")
+        assert settings.desktop_screenshot_dir == (
+            settings.data_dir / "screenshots" / "desktop"
+        )
+        assert settings.mobile_screenshot_dir == (
+            settings.data_dir / "screenshots" / "mobile"
+        )
         assert settings.desktop_keyboard_layout == "auto"
         assert settings.automation_backend == "desktop"
 
@@ -118,9 +124,9 @@ class TestSettings:
         assert settings.actions_computer_tool_action_timeout_seconds == 600.0
 
     def test_planning_cache_defaults(self):
-        settings = load_settings({})
+        settings = Settings()
         assert settings.enable_planning_cache is True
-        assert settings.planning_cache_path == Path("data/planning_cache.json")
+        assert settings.planning_cache_path == settings.data_dir / "planning_cache.json"
 
     def test_planning_cache_env_loader(self):
         settings = load_settings(
@@ -133,9 +139,150 @@ class TestSettings:
         assert settings.planning_cache_path == Path("tmp/planning_cache_override.json")
 
     def test_situational_cache_defaults(self):
-        settings = load_settings({})
+        settings = Settings()
         assert settings.enable_situational_cache is True
-        assert settings.situational_cache_path == Path("data/situational_cache.json")
+        assert settings.situational_cache_path == (
+            settings.data_dir / "situational_cache.json"
+        )
+
+    def test_default_data_paths_use_project_scoped_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        cwd = tmp_path / "My Project!"
+        home = tmp_path / "haindy-home"
+        cwd.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path / "user-home"))
+        monkeypatch.chdir(cwd)
+
+        settings = load_settings({"HAINDY_HOME": str(home)})
+        expected_data_dir = build_project_data_dir(home, cwd)
+
+        assert settings.data_dir == expected_data_dir
+        assert settings.data_dir.parent == home / "data" / "projects"
+        assert settings.data_dir.name.startswith("my-project-")
+        assert len(settings.data_dir.name.rsplit("-", 1)[-1]) == 12
+        assert settings.screenshots_dir == expected_data_dir / "screenshots"
+        assert settings.desktop_screenshot_dir == (
+            expected_data_dir / "screenshots" / "desktop"
+        )
+        assert settings.windows_screenshot_dir == (
+            expected_data_dir / "screenshots" / "windows"
+        )
+        assert settings.mobile_screenshot_dir == (
+            expected_data_dir / "screenshots" / "mobile"
+        )
+        assert settings.ios_screenshot_dir == (
+            expected_data_dir / "screenshots" / "ios"
+        )
+        assert settings.macos_screenshot_dir == (
+            expected_data_dir / "screenshots" / "macos"
+        )
+        assert settings.model_log_path == (
+            expected_data_dir / "model_logs" / "model_calls.jsonl"
+        )
+        assert settings.planning_cache_path == (
+            expected_data_dir / "planning_cache.json"
+        )
+        assert settings.situational_cache_path == (
+            expected_data_dir / "situational_cache.json"
+        )
+        assert settings.task_plan_cache_path == (
+            expected_data_dir / "task_plan_cache.json"
+        )
+        assert settings.execution_replay_cache_path == (
+            expected_data_dir / "execution_replay_cache.json"
+        )
+        assert settings.linux_coordinate_cache_path == (
+            expected_data_dir / "linux_cache" / "coordinates.json"
+        )
+        assert settings.macos_coordinate_cache_path == (
+            expected_data_dir / "macos_cache" / "coordinates.json"
+        )
+
+    def test_data_dir_override_is_exact_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path / "user-home"))
+        data_dir = tmp_path / "explicit-data"
+
+        settings = load_settings(
+            {
+                "HAINDY_HOME": str(tmp_path / "haindy-home"),
+                "HAINDY_DATA_DIR": str(data_dir),
+            }
+        )
+
+        assert settings.data_dir == data_dir
+        assert settings.screenshots_dir == data_dir / "screenshots"
+        assert settings.model_log_path == (
+            data_dir / "model_logs" / "model_calls.jsonl"
+        )
+        assert settings.desktop_screenshot_dir == (data_dir / "screenshots" / "desktop")
+        assert settings.planning_cache_path == data_dir / "planning_cache.json"
+
+    def test_settings_file_data_dir_override_is_exact_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        user_home = tmp_path / "user-home"
+        data_dir = tmp_path / "settings-data"
+        settings_path = user_home / ".haindy" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(
+            json.dumps({"storage": {"data_dir": str(data_dir)}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HOME", str(user_home))
+
+        settings = load_settings({})
+
+        assert settings.data_dir == data_dir
+        assert settings.screenshots_dir == data_dir / "screenshots"
+        assert settings.model_log_path == (
+            data_dir / "model_logs" / "model_calls.jsonl"
+        )
+
+    def test_specific_path_overrides_win_over_data_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path / "user-home"))
+        data_dir = tmp_path / "explicit-data"
+
+        settings = load_settings(
+            {
+                "HAINDY_HOME": str(tmp_path / "haindy-home"),
+                "HAINDY_DATA_DIR": str(data_dir),
+                "HAINDY_MODEL_LOG_PATH": "legacy/model_calls.jsonl",
+                "HAINDY_DESKTOP_SCREENSHOT_DIR": "legacy/screenshots/desktop",
+                "HAINDY_PLANNING_CACHE_PATH": "legacy/planning_cache.json",
+            }
+        )
+
+        assert settings.data_dir == data_dir
+        assert settings.model_log_path == Path("legacy/model_calls.jsonl")
+        assert settings.desktop_screenshot_dir == Path("legacy/screenshots/desktop")
+        assert settings.planning_cache_path == Path("legacy/planning_cache.json")
+        assert settings.mobile_screenshot_dir == data_dir / "screenshots" / "mobile"
+
+    def test_create_directories_includes_all_data_dirs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.chdir(tmp_path)
+        data_dir = tmp_path / "data-root"
+        settings = Settings(
+            data_dir=data_dir,
+            haindy_home=tmp_path / "haindy-home",
+            cache_dir=tmp_path / "cache",
+        )
+
+        settings.create_directories()
+
+        assert (data_dir / "screenshots" / "desktop").is_dir()
+        assert (data_dir / "screenshots" / "mobile").is_dir()
+        assert (data_dir / "screenshots" / "ios").is_dir()
+        assert (data_dir / "screenshots" / "macos").is_dir()
+        assert (data_dir / "screenshots" / "windows").is_dir()
+        assert (data_dir / "model_logs").is_dir()
+        assert (data_dir / "journals").is_dir()
 
     def test_situational_cache_env_loader(self):
         settings = load_settings(

--- a/tests/test_journal_manager.py
+++ b/tests/test_journal_manager.py
@@ -1,7 +1,10 @@
 """JournalManager tests for provider-neutral action journaling."""
 
+from pathlib import Path
+
 import pytest
 
+from haindy.config.settings import build_project_data_dir, get_settings
 from haindy.core.types import TestPlan, TestStep
 from haindy.journal.manager import JournalManager
 from haindy.journal.models import ExecutionMode, JournalActionResult
@@ -21,6 +24,28 @@ def _plan() -> TestPlan:
         test_cases=[],
         steps=[step],
     )
+
+
+def test_default_journal_dir_uses_settings_data_root(
+    monkeypatch, tmp_path: Path
+) -> None:
+    cwd = tmp_path / "repo"
+    home = tmp_path / "haindy-home"
+    cwd.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "user-home"))
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(
+        "haindy.config.settings._merge_runtime_env",
+        lambda: {"HAINDY_HOME": str(home)},
+    )
+    get_settings.cache_clear()
+
+    try:
+        manager = JournalManager()
+
+        assert manager.journal_dir == build_project_data_dir(home, cwd) / "journals"
+    finally:
+        get_settings.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_trace.py
+++ b/tests/test_run_trace.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from haindy.config.settings import build_project_data_dir, get_settings
 from haindy.core.types import StepResult, TestStatus, TestStep
 from haindy.runtime.trace import RunTraceWriter, load_model_calls_for_run
 
@@ -27,8 +28,8 @@ def test_run_trace_writer_writes_trace(tmp_path: Path) -> None:
         action=step.action,
         expected_result=step.expected_result,
         actual_result="ok",
-        screenshot_before="data/screenshots/step_before.png",
-        screenshot_after="data/screenshots/step_after.png",
+        screenshot_before="screenshots/step_before.png",
+        screenshot_after="screenshots/step_after.png",
         actions_performed=[{"action_type": "click", "x": 10, "y": 20}],
     )
     trace.record_step(
@@ -54,14 +55,36 @@ def test_run_trace_writer_writes_trace(tmp_path: Path) -> None:
     assert stored_step["scenario"] == "test_scenario"
     assert stored_step["plan_cache_hit"] is True
     assert (
-        stored_step["step_result"]["screenshot_before"]
-        == "data/screenshots/step_before.png"
+        stored_step["step_result"]["screenshot_before"] == "screenshots/step_before.png"
     )
     assert (
-        stored_step["step_result"]["screenshot_after"]
-        == "data/screenshots/step_after.png"
+        stored_step["step_result"]["screenshot_after"] == "screenshots/step_after.png"
     )
     assert stored_step["step_result"]["actions_performed"][0]["action_type"] == "click"
+
+
+def test_run_trace_writer_default_path_follows_settings_data_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    cwd = tmp_path / "repo"
+    home = tmp_path / "haindy-home"
+    cwd.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "user-home"))
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(
+        "haindy.config.settings._merge_runtime_env",
+        lambda: {"HAINDY_HOME": str(home)},
+    )
+    get_settings.cache_clear()
+
+    try:
+        trace = RunTraceWriter("default_run")
+
+        assert trace.path == (
+            build_project_data_dir(home, cwd) / "traces" / "default_run.json"
+        )
+    finally:
+        get_settings.cache_clear()
 
 
 def test_load_model_calls_for_run_filters_by_run_id(tmp_path: Path) -> None:

--- a/tests/test_runtime_environment.py
+++ b/tests/test_runtime_environment.py
@@ -94,13 +94,13 @@ def test_resolve_runtime_environment_from_context_uses_target_type_for_browser()
 
 def test_coordinate_cache_path_for_environment_uses_mobile_path_for_mobile() -> None:
     settings = SimpleNamespace(
-        linux_coordinate_cache_path=Path("data/linux_cache/coordinates.json"),
-        mobile_coordinate_cache_path=Path("data/mobile_cache/coordinates.json"),
+        linux_coordinate_cache_path=Path("/tmp/linux_cache/coordinates.json"),
+        mobile_coordinate_cache_path=Path("/tmp/mobile_cache/coordinates.json"),
     )
 
     assert coordinate_cache_path_for_environment(settings, "browser") == Path(
-        "data/linux_cache/coordinates.json"
+        "/tmp/linux_cache/coordinates.json"
     )
     assert coordinate_cache_path_for_environment(settings, "android") == Path(
-        "data/mobile_cache/coordinates.json"
+        "/tmp/mobile_cache/coordinates.json"
     )

--- a/tests/test_tool_call_mode_paths.py
+++ b/tests/test_tool_call_mode_paths.py
@@ -5,8 +5,14 @@ from pathlib import Path
 
 from haindy.tool_call_mode.models import SessionMetadata
 from haindy.tool_call_mode.paths import (
+    ensure_session_layout,
+    get_action_artifacts_dir,
+    get_daemon_log_path,
     get_haindy_home,
+    get_logs_dir,
+    get_screenshots_dir,
     get_session_dir,
+    get_sessions_root,
     load_session_metadata,
     prune_dead_sessions,
     save_session_metadata,
@@ -18,6 +24,24 @@ def test_get_haindy_home_prefers_env_override(monkeypatch, tmp_path: Path) -> No
     monkeypatch.setenv("HAINDY_HOME", str(tmp_path / "custom-home"))
 
     assert get_haindy_home() == (tmp_path / "custom-home")
+
+
+def test_session_layout_stays_under_home_sessions(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "haindy-home"
+    session_id = "session-123"
+    monkeypatch.setenv("HAINDY_HOME", str(home))
+
+    session_dir = ensure_session_layout(session_id)
+
+    assert get_sessions_root() == home / "sessions"
+    assert session_dir == home / "sessions" / session_id
+    assert get_screenshots_dir(session_id) == session_dir / "screenshots"
+    assert get_logs_dir(session_id) == session_dir / "logs"
+    assert get_daemon_log_path(session_id) == session_dir / "logs" / "daemon.log"
+    assert get_action_artifacts_dir(session_id) == session_dir / "action_artifacts"
+    assert get_screenshots_dir(session_id).is_dir()
+    assert get_logs_dir(session_id).is_dir()
+    assert get_action_artifacts_dir(session_id).is_dir()
 
 
 def test_save_and_load_session_metadata_round_trip(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Move default HAINDY data-family artifacts out of the invocation directory into `HAINDY_HOME/data/projects/<project-id>`.
- Preserve `HAINDY_DATA_DIR` / `storage.data_dir` as exact root overrides, with specific path overrides still taking precedence.
- Keep tool-call session state under `HAINDY_HOME/sessions/<session-id>` and update docs, skills, and forensics helpers for the new layout.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format .`
- `.venv/bin/mypy haindy`
- `.venv/bin/pytest`
- Manual HAINDY Android explore smoke test verified session artifacts and model logs stayed under `~/.haindy` and no repo-local `./data` directory was created.