### PR TITLE
Update HAINDY tool-call forensics and prepare v0.4.2 release

### DIFF
--- a/.codex/skills/haindy-test-forensics/SKILL.md
+++ b/.codex/skills/haindy-test-forensics/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: haindy-test-forensics
-description: Investigate failed HAINDY runtime test executions by reconstructing the sequence of events from `<data-root>/traces/*.json`, `<data-root>/model_logs/model_calls.jsonl`, screenshots, and `reports/run-id/` artifacts, then explain what happened and suggest fixes. Use when a user asks for forensics on the last or a specific HAINDY run, wants a high-level failure timeline, issue analysis, or candidate fixes from local HAINDY data artifacts. Do not use this skill for ordinary `pytest` stack-trace debugging.
+description: Investigate failed HAINDY batch or tool-call executions by reconstructing events from the effective data root, model logs, reports, and tool-call session artifacts under `~/.haindy/sessions/<session-id>/`. Use when a user asks for forensics on the last or a specific HAINDY run/session, wants a high-level failure timeline, issue analysis, or candidate fixes from local HAINDY artifacts. Do not use this skill for ordinary `pytest` stack-trace debugging.
 ---
 
 # Haindy Test Forensics
 
 ## Overview
 
-Analyze a failed HAINDY execution run from local artifacts and explain it in plain English.
-Prioritize artifacts under the effective HAINDY data root, reconstruct the run sequence, identify the most likely failure category, and propose fixes without inventing non-visual root causes.
+Analyze a failed HAINDY execution run or tool-call session from local artifacts and explain it in plain English.
+Prioritize artifacts under the effective HAINDY data root and, for tool-call mode, the session-local artifact directory. Reconstruct the run or session sequence, identify the most likely failure category, and propose fixes without inventing non-visual root causes.
 
-By default, the data root is `~/.haindy/data/projects/<project-id>` for the resolved current working directory. `HAINDY_DATA_DIR` or `storage.data_dir` overrides it exactly. If a user has old copied env vars pointing at `data/...`, artifacts may still be under `./data` until those overrides are removed.
+By default, the data root is `~/.haindy/data/projects/<project-id>` for the resolved current working directory. `HAINDY_DATA_DIR` or `storage.data_dir` overrides it exactly. Tool-call session state is separate under `~/.haindy/sessions/<session-id>/`, or under `HAINDY_HOME/sessions/<session-id>` when `HAINDY_HOME` is set. If a user has old copied env vars pointing at `data/...`, artifacts may still be under `./data` until those overrides are removed; do not scan legacy `./data` unless it is the effective configured root.
 
 ## Guardrails
 
@@ -22,16 +22,18 @@ By default, the data root is `~/.haindy/data/projects/<project-id>` for the reso
   - What the app or site visibly did.
   - What HAINDY visibly did.
   - What the verifier/reporting layer concluded.
-- Prefer the raw trace, action JSON, model logs, and screenshots over prose in the HTML report.
+- Prefer raw traces, tool-call action artifacts, model logs, session logs, and screenshots over prose in the HTML report.
 
 ## Evidence Order
 
-Read artifacts in this order unless the user points you somewhere else:
+Read artifacts in this order unless the user points you somewhere else.
+
+### Batch runs and tool-call background `test`
 
 1. `<data-root>/traces/<run_id>.json`
-This is the authoritative run timeline: backend, start/end times, step ordering, pass/fail status, expected vs actual results, and before/after screenshot paths.
+This is the authoritative test timeline: backend, start/end times, step ordering, pass/fail status, expected vs actual results, and before/after screenshot paths.
 
-2. `reports/<run_id>/*-actions.json`
+2. `<reports-dir>/<run_id>/*-actions.json`
 Use this for per-action detail: interpreted action type, prompts, automation calls, verification summaries, and bug-report payloads.
 
 3. `<data-root>/model_logs/model_calls.jsonl`
@@ -43,34 +45,61 @@ Use these as visual evidence referenced by model logs. They are often the best w
 5. `debug_screenshots/<run_id>/`
 Use these when the trace or action JSON points to step-level before/after screenshots outside the data root.
 
-6. `reports/<run_id>/*.html`
+6. `<reports-dir>/<run_id>/*.html`
 Treat the HTML report as a convenience view, not the source of truth.
+
+### Tool-call sessions
+
+1. `<haindy-home>/sessions/<session-id>/session.json`
+Use this for `latest_background_run_id`, latest phase/progress fields, latest screenshot, backend, command counters, and session status.
+
+2. `<haindy-home>/sessions/<session-id>/action_artifacts/*.json`
+For background `test`, these are the best per-step tool-call artifacts: action, verification, phase, status transitions, and step result.
+
+3. `<data-root>/traces/<run_id>.json`
+Use this when `session.json` or an action artifact provides a `run_id`. Tool-call `test` should usually have this trace; `explore` and one-off `act` may not.
+
+4. `<data-root>/model_logs/model_calls.jsonl`
+Filter by `run_id` when one exists. For session-only evidence, also inspect session-local AI logs.
+
+5. `<haindy-home>/sessions/<session-id>/screenshots/`
+Use these for command/status screenshots and promoted background-task screenshots.
+
+6. `<haindy-home>/sessions/<session-id>/logs/ai_interactions.jsonl` and `logs/daemon.log`
+Use AI interactions and daemon logs to understand session-only `explore`/`act`, daemon failures, timeouts, or missing trace cases.
 
 ## Workflow
 
-1. Resolve the run.
-Default to the latest failed run unless the user names a `run_id` or specific artifact path.
+1. Resolve the run or session.
+Default to the latest failed trace unless the user names a `run_id`, `session_id`, or specific artifact path. For tool-call session issues without a `run_id`, resolve the session first.
 Use the helper:
 
 ```bash
 python .codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py --latest-failed
 python .codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py --run-id <run_id>
+python .codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py --session-id <session_id>
+python .codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py --latest-session
 ```
 
-2. Reconstruct the timeline from the trace.
+The helper uses effective HAINDY settings for `data_dir`, `reports_dir`, and `haindy_home`. It does not auto-scan legacy `./data` unless that path is configured.
+
+2. Reconstruct the timeline from the authoritative source.
+For batch and tool-call `test`, start with the trace. For tool-call `explore` or `act` without a trace, start with `session.json`, session screenshots, AI interactions, and daemon logs.
 Identify:
 - setup steps that passed
 - the first failing step or first suspicious divergence
 - whether the failure is execution-time, verification-time, or downstream fallout
 - what immediately preceded the failure
+- whether a tool-call session has only session-local evidence and no durable trace
 
-3. Read the matching action JSON.
+3. Read the matching action JSON or tool-call action artifact.
 Confirm:
 - action type (`click`, `type`, `wait`, `skip_navigation`, `reset_app`, etc.)
 - prompt given to the CU model
 - any automation calls and coordinates
 - verification verdict and reasoning
 - any generated bug report or blocker classification
+- tool-call phase/status transitions and latest action artifact path when present
 
 4. Filter model calls by `run_id`.
 Look for:
@@ -86,12 +115,20 @@ Typical command:
 rg -n "\"run_id\": \"<run_id>\"" <data-root>/model_logs/model_calls.jsonl
 ```
 
-5. Check the screenshots tied to the failing step.
+For session-only `explore` or `act`, inspect session-local logs instead:
+
+```bash
+sed -n '1,200p' <haindy-home>/sessions/<session-id>/logs/ai_interactions.jsonl
+sed -n '1,200p' <haindy-home>/sessions/<session-id>/logs/daemon.log
+```
+
+5. Check the screenshots tied to the failing step or session command.
 Use screenshots to answer:
 - Was the expected control/screen actually visible?
 - Did HAINDY tap/type on the right target?
 - Did the app show a business error, auth error, loading state, or unchanged screen?
 - Did the verifier interpret the final screen correctly?
+- Did the session stop because the app/device state changed outside HAINDY's control?
 
 6. Classify the failure before proposing fixes.
 Use one primary category:
@@ -100,6 +137,7 @@ Use one primary category:
 - `verification_or_reporting`: execution appears correct, but the verifier/reporting path marked it wrong.
 - `environment_or_setup`: device, app reset, account state, backend selection, or test environment made the run invalid.
 - `test_plan_or_expectation`: the plan's expected result does not match the product's intended or current behavior.
+- `tool_call_session_runtime`: the session daemon, session state, command dispatch, timeout, or background-task lifecycle failed before a normal trace/report could be produced.
 
 7. Write the answer in four parts:
 - High-level sequence of events.
@@ -113,6 +151,7 @@ Use one primary category:
 - If the app shows an auth or business error after a correct visible interaction, call that an app/backend/account/environment issue first, not a CU determinism issue.
 - If the action prompt, target, or coordinates are visibly wrong, call it an automation execution issue.
 - If the screenshots look successful but the verifier says fail, call it a verification/reporting issue.
+- If a tool-call session has no trace, do not invent a missing test-run root cause. Explain whether the flow was session-only (`explore`/`act`) or whether a background `test` failed before trace creation.
 - If a failure in one step makes later failures inevitable, say so explicitly and separate the first-cause failure from downstream failures.
 - If evidence is ambiguous, say what is known, what is uncertain, and which artifact would disambiguate it.
 
@@ -127,6 +166,7 @@ Include:
 - `Possible fixes`
 
 When citing evidence, prefer concrete artifact paths and step numbers.
+For session-only evidence, cite session IDs, action artifact filenames, screenshot filenames, and log paths instead of pretending a trace exists.
 Do not overstate confidence.
 
 ## Example Trigger Phrases
@@ -135,3 +175,5 @@ Do not overstate confidence.
 - `Analyze the latest failed HAINDY run from the data root.`
 - `Do forensics on run 20260313T144056Z_447777a8 and suggest fixes.`
 - `Explain the sequence of events and root cause for the last mobile_adb failure.`
+- `The latest tool-call session got stuck. Figure out what happened.`
+- `Analyze session 0f4d... from ~/.haindy/sessions and explain why explore stopped.`

--- a/.codex/skills/haindy-test-forensics/agents/openai.yaml
+++ b/.codex/skills/haindy-test-forensics/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Haindy Test Forensics"
-  short_description: "Forensics for failed Haindy runs from local data artifacts"
-  default_prompt: "Use $haindy-test-forensics to investigate the last failed HAINDY test run, reconstruct the high-level sequence of events, explain the issue, and propose likely fixes from the run artifacts in the effective HAINDY data root."
+  short_description: "Forensics for failed Haindy runs and tool-call sessions"
+  default_prompt: "Use $haindy-test-forensics to investigate the last failed HAINDY run or tool-call session, reconstruct the high-level sequence of events, explain the issue, and propose likely fixes from the effective HAINDY data root and session-local artifacts."

--- a/.codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py
+++ b/.codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
-"""Locate HAINDY run artifacts for failed-run forensics."""
+"""Locate HAINDY run and tool-call session artifacts for forensics."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
+
+_SETTINGS_NOTE = (
+    "Artifact roots come from the effective HAINDY settings. Legacy ./data paths "
+    "are not scanned unless they are configured through HAINDY_DATA_DIR or "
+    "storage.data_dir."
+)
 
 
 def _repo_root() -> Path:
@@ -22,13 +29,18 @@ def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _data_root() -> Path:
+def _load_runtime_settings() -> Any:
     from haindy.config.settings import load_settings
 
-    return load_settings().data_dir
+    return load_settings()
+
+
+def _expand_path(value: Path | str) -> Path:
+    return Path(value).expanduser()
 
 
 def _display_path(path: Path, repo_root: Path) -> str:
+    path = Path(path)
     try:
         return str(path.relative_to(repo_root))
     except ValueError:
@@ -47,15 +59,17 @@ def _select_trace(
     latest_failed: bool,
 ) -> Path:
     trace_dir = data_root / "traces"
-    traces = _trace_files(data_root)
-    if not traces:
-        raise FileNotFoundError(f"No trace files found under {trace_dir}")
-
     if run_id:
         candidate = trace_dir / f"{run_id}.json"
         if not candidate.exists():
-            raise FileNotFoundError(f"Trace for run_id {run_id!r} not found")
+            raise FileNotFoundError(
+                f"Trace for run_id {run_id!r} not found under {trace_dir}"
+            )
         return candidate
+
+    traces = _trace_files(data_root)
+    if not traces:
+        raise FileNotFoundError(f"No trace files found under {trace_dir}")
 
     if latest:
         return traces[-1]
@@ -66,6 +80,97 @@ def _select_trace(
             return trace_path
 
     raise FileNotFoundError(f"No failed trace files found under {trace_dir}")
+
+
+def _session_root(haindy_home: Path) -> Path:
+    return _expand_path(haindy_home) / "sessions"
+
+
+def _session_dirs(haindy_home: Path) -> list[Path]:
+    root = _session_root(haindy_home)
+    if not root.exists():
+        return []
+    return sorted(path for path in root.iterdir() if path.is_dir())
+
+
+def _metadata_path(session_dir: Path) -> Path:
+    return session_dir / "session.json"
+
+
+def _load_session_metadata(session_dir: Path) -> dict[str, Any] | None:
+    path = _metadata_path(session_dir)
+    if not path.exists():
+        return None
+    try:
+        return _load_json(path)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _select_session(haindy_home: Path, session_id: str | None) -> Path:
+    if session_id:
+        candidate = _session_root(haindy_home) / session_id
+        if not candidate.exists():
+            raise FileNotFoundError(f"Tool-call session {session_id!r} not found")
+        return candidate
+
+    sessions = _session_dirs(haindy_home)
+    if not sessions:
+        raise FileNotFoundError(
+            f"No tool-call sessions found under {_session_root(haindy_home)}"
+        )
+
+    def sort_key(session_dir: Path) -> float:
+        metadata = _metadata_path(session_dir)
+        try:
+            if metadata.exists():
+                return metadata.stat().st_mtime
+            return session_dir.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    return max(sessions, key=sort_key)
+
+
+def _session_id_from_dir(session_dir: Path, metadata: dict[str, Any] | None) -> str:
+    if metadata and metadata.get("session_id"):
+        return str(metadata["session_id"])
+    return session_dir.name
+
+
+def _action_artifact_files(session_dir: Path) -> list[Path]:
+    return sorted((session_dir / "action_artifacts").glob("*.json"))
+
+
+def _action_artifact_run_id(path: Path) -> str | None:
+    try:
+        payload = _load_json(path)
+    except (OSError, json.JSONDecodeError):
+        return None
+    value = payload.get("run_id")
+    return str(value) if value else None
+
+
+def _matching_action_artifacts(session_dir: Path, run_id: str | None) -> list[Path]:
+    artifacts = _action_artifact_files(session_dir)
+    if not run_id:
+        return artifacts
+    return [path for path in artifacts if _action_artifact_run_id(path) == run_id]
+
+
+def _session_matches_run(session_dir: Path, run_id: str) -> bool:
+    metadata = _load_session_metadata(session_dir) or {}
+    if metadata.get("latest_background_run_id") == run_id:
+        return True
+    return bool(_matching_action_artifacts(session_dir, run_id))
+
+
+def _sessions_for_run(haindy_home: Path, run_id: str) -> list[Path]:
+    return [
+        session_dir
+        for session_dir in _session_dirs(haindy_home)
+        if _session_matches_run(session_dir, run_id)
+    ]
 
 
 def _failed_steps(trace: dict[str, Any]) -> list[dict[str, Any]]:
@@ -89,16 +194,32 @@ def _failed_steps(trace: dict[str, Any]) -> list[dict[str, Any]]:
     return failed
 
 
-def _summarize(trace_path: Path, repo_root: Path, data_root: Path) -> dict[str, Any]:
+def _path_if_exists(path: Path, repo_root: Path) -> str | None:
+    return _display_path(path, repo_root) if path.exists() else None
+
+
+def _display_paths(paths: Sequence[Path], repo_root: Path) -> list[str]:
+    return [_display_path(path, repo_root) for path in paths]
+
+
+def _model_log_path(trace: dict[str, Any], configured_model_log_path: Path) -> str:
+    metadata_path = (trace.get("run_metadata") or {}).get("model_log_path")
+    return str(metadata_path or configured_model_log_path)
+
+
+def _summarize_trace(
+    trace_path: Path,
+    *,
+    repo_root: Path,
+    data_root: Path,
+    reports_dir: Path,
+    configured_model_log_path: Path,
+) -> dict[str, Any]:
     trace = _load_json(trace_path)
     run_id = str(trace.get("run_id") or trace_path.stem)
-    report_dir = repo_root / "reports" / run_id
-    actions_json = sorted(
-        str(path.relative_to(repo_root)) for path in report_dir.glob("*-actions.json")
-    )
-    html_reports = sorted(
-        str(path.relative_to(repo_root)) for path in report_dir.glob("*.html")
-    )
+    report_dir = reports_dir / run_id
+    actions_json = sorted(report_dir.glob("*-actions.json"))
+    html_reports = sorted(report_dir.glob("*.html"))
     debug_dir = repo_root / "debug_screenshots" / run_id
 
     steps = trace.get("steps", [])
@@ -110,13 +231,13 @@ def _summarize(trace_path: Path, repo_root: Path, data_root: Path) -> dict[str, 
     passed_steps = sum(1 for status in statuses if status == "passed")
     failed_steps = _failed_steps(trace)
 
-    model_log_path = ((trace.get("run_metadata") or {}).get("model_log_path")) or str(
-        data_root / "model_logs" / "model_calls.jsonl"
-    )
+    model_log_path = _model_log_path(trace, configured_model_log_path)
 
     return {
+        "mode": "trace",
         "run_id": run_id,
         "data_root": str(data_root),
+        "reports_dir": str(reports_dir),
         "trace_path": _display_path(trace_path, repo_root),
         "success": bool(trace.get("success")),
         "started_at": trace.get("started_at"),
@@ -126,55 +247,250 @@ def _summarize(trace_path: Path, repo_root: Path, data_root: Path) -> dict[str, 
         ),
         "test_plan_name": (trace.get("run_metadata") or {}).get("test_plan_name"),
         "model_log_path": model_log_path,
-        "report_dir": (
-            str(report_dir.relative_to(repo_root)) if report_dir.exists() else None
+        "model_screenshot_dir": _path_if_exists(
+            data_root / "model_logs" / "screenshots",
+            repo_root,
         ),
-        "actions_json_paths": actions_json,
-        "html_report_paths": html_reports,
+        "report_dir": (
+            _display_path(report_dir, repo_root) if report_dir.exists() else None
+        ),
+        "actions_json_paths": _display_paths(actions_json, repo_root),
+        "html_report_paths": _display_paths(html_reports, repo_root),
         "debug_screenshot_dir": (
-            str(debug_dir.relative_to(repo_root)) if debug_dir.exists() else None
+            _display_path(debug_dir, repo_root) if debug_dir.exists() else None
         ),
         "total_steps": len(steps),
         "passed_steps": passed_steps,
         "failed_steps": failed_steps,
         "first_failed_step": failed_steps[0] if failed_steps else None,
         "model_log_rg_hint": f'rg -n \'"run_id": "{run_id}"\' {model_log_path}',
+        "settings_note": _SETTINGS_NOTE,
     }
 
 
-def main() -> int:
+def _summarize_session(
+    session_dir: Path,
+    *,
+    repo_root: Path,
+    data_root: Path,
+    reports_dir: Path,
+    configured_model_log_path: Path,
+    run_id_filter: str | None = None,
+    include_linked_trace: bool = True,
+) -> dict[str, Any]:
+    metadata = _load_session_metadata(session_dir) or {}
+    session_id = _session_id_from_dir(session_dir, metadata)
+    latest_run_id = metadata.get("latest_background_run_id")
+    run_id = run_id_filter or (str(latest_run_id) if latest_run_id else None)
+    action_artifacts = _matching_action_artifacts(session_dir, run_id_filter)
+    screenshot_dir = session_dir / "screenshots"
+    screenshots = sorted(screenshot_dir.glob("*"))
+    daemon_log_path = session_dir / "logs" / "daemon.log"
+    ai_log_path = session_dir / "logs" / "ai_interactions.jsonl"
+    trace_path = data_root / "traces" / f"{run_id}.json" if run_id else None
+    linked_trace = None
+    if include_linked_trace and trace_path and trace_path.exists():
+        linked_trace = _summarize_trace(
+            trace_path,
+            repo_root=repo_root,
+            data_root=data_root,
+            reports_dir=reports_dir,
+            configured_model_log_path=configured_model_log_path,
+        )
+
+    return {
+        "mode": "tool_call_session",
+        "session_id": session_id,
+        "run_id": run_id,
+        "data_root": str(data_root),
+        "reports_dir": str(reports_dir),
+        "session_dir": _display_path(session_dir, repo_root),
+        "session_metadata_path": _path_if_exists(
+            _metadata_path(session_dir), repo_root
+        ),
+        "session_status": metadata.get("status"),
+        "backend": metadata.get("backend"),
+        "created_at": metadata.get("created_at"),
+        "last_command_at": metadata.get("last_command_at"),
+        "last_command_name": metadata.get("last_command_name"),
+        "latest_background_run_id": latest_run_id,
+        "latest_test_phase": metadata.get("latest_test_phase"),
+        "latest_test_progress_at": metadata.get("latest_test_progress_at"),
+        "latest_test_action_artifact_path": metadata.get(
+            "latest_test_action_artifact_path"
+        ),
+        "latest_screenshot_path": metadata.get("latest_screenshot_path"),
+        "action_artifact_paths": _display_paths(action_artifacts, repo_root),
+        "session_screenshot_dir": _path_if_exists(screenshot_dir, repo_root),
+        "session_screenshot_count": len(screenshots),
+        "latest_session_screenshot_paths": _display_paths(screenshots[-5:], repo_root),
+        "daemon_log_path": _path_if_exists(daemon_log_path, repo_root),
+        "ai_interactions_log_path": _path_if_exists(ai_log_path, repo_root),
+        "linked_trace": linked_trace,
+        "model_log_path": str(configured_model_log_path),
+        "model_log_rg_hint": (
+            f'rg -n \'"run_id": "{run_id}"\' {configured_model_log_path}'
+            if run_id
+            else None
+        ),
+        "settings_note": _SETTINGS_NOTE,
+    }
+
+
+def _summarize_run_id(
+    run_id: str,
+    *,
+    repo_root: Path,
+    data_root: Path,
+    reports_dir: Path,
+    haindy_home: Path,
+    configured_model_log_path: Path,
+) -> dict[str, Any]:
+    trace_path = data_root / "traces" / f"{run_id}.json"
+    matching_sessions = [
+        _summarize_session(
+            session_dir,
+            repo_root=repo_root,
+            data_root=data_root,
+            reports_dir=reports_dir,
+            configured_model_log_path=configured_model_log_path,
+            run_id_filter=run_id,
+            include_linked_trace=False,
+        )
+        for session_dir in _sessions_for_run(haindy_home, run_id)
+    ]
+
+    if not trace_path.exists():
+        if matching_sessions:
+            return {
+                "mode": "run_id_session_only",
+                "run_id": run_id,
+                "data_root": str(data_root),
+                "reports_dir": str(reports_dir),
+                "trace_path": None,
+                "matching_tool_call_sessions": matching_sessions,
+                "warning": (
+                    f"No trace for run_id {run_id!r} was found under "
+                    f"{data_root / 'traces'}, but matching tool-call session "
+                    "artifacts were found."
+                ),
+                "settings_note": _SETTINGS_NOTE,
+            }
+        raise FileNotFoundError(
+            f"Trace for run_id {run_id!r} not found under {data_root / 'traces'}"
+        )
+
+    summary = _summarize_trace(
+        trace_path,
+        repo_root=repo_root,
+        data_root=data_root,
+        reports_dir=reports_dir,
+        configured_model_log_path=configured_model_log_path,
+    )
+    summary["matching_tool_call_sessions"] = matching_sessions
+    return summary
+
+
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Locate HAINDY run artifacts for failed-run forensics."
     )
-    parser.add_argument("--run-id", help="Specific HAINDY run_id to inspect.")
-    parser.add_argument(
+    selector = parser.add_mutually_exclusive_group()
+    selector.add_argument("--run-id", help="Specific HAINDY run_id to inspect.")
+    selector.add_argument("--session-id", help="Specific tool-call session to inspect.")
+    selector.add_argument(
         "--latest",
         action="store_true",
         help="Use the latest trace whether it passed or failed.",
     )
-    parser.add_argument(
+    selector.add_argument(
         "--latest-failed",
         action="store_true",
         help="Use the latest failed trace. This is the default.",
     )
-    args = parser.parse_args()
+    selector.add_argument(
+        "--latest-session",
+        action="store_true",
+        help="Use the newest tool-call session directory.",
+    )
+    args = parser.parse_args(argv)
 
     repo_root = _repo_root()
-    data_root = _data_root()
-    latest_failed = args.latest_failed or (not args.run_id and not args.latest)
+    settings = _load_runtime_settings()
+    data_root = _expand_path(settings.data_dir)
+    reports_dir = _expand_path(settings.reports_dir)
+    haindy_home = _expand_path(settings.haindy_home)
+    configured_model_log_path = _expand_path(settings.model_log_path)
+    latest_failed = (
+        not any(
+            [
+                args.run_id,
+                args.session_id,
+                args.latest,
+                args.latest_failed,
+                args.latest_session,
+            ]
+        )
+        or args.latest_failed
+    )
 
     try:
-        trace_path = _select_trace(
-            data_root=data_root,
-            run_id=args.run_id,
-            latest=args.latest,
-            latest_failed=latest_failed,
-        )
+        if args.session_id or args.latest_session:
+            session_dir = _select_session(
+                haindy_home,
+                session_id=args.session_id,
+            )
+            summary = _summarize_session(
+                session_dir,
+                repo_root=repo_root,
+                data_root=data_root,
+                reports_dir=reports_dir,
+                configured_model_log_path=configured_model_log_path,
+            )
+        elif args.run_id:
+            summary = _summarize_run_id(
+                args.run_id,
+                repo_root=repo_root,
+                data_root=data_root,
+                reports_dir=reports_dir,
+                haindy_home=haindy_home,
+                configured_model_log_path=configured_model_log_path,
+            )
+        else:
+            trace_path = _select_trace(
+                data_root=data_root,
+                run_id=None,
+                latest=args.latest,
+                latest_failed=latest_failed,
+            )
+            summary = _summarize_trace(
+                trace_path,
+                repo_root=repo_root,
+                data_root=data_root,
+                reports_dir=reports_dir,
+                configured_model_log_path=configured_model_log_path,
+            )
+            run_id = str(summary.get("run_id") or "")
+            summary["matching_tool_call_sessions"] = (
+                [
+                    _summarize_session(
+                        session_dir,
+                        repo_root=repo_root,
+                        data_root=data_root,
+                        reports_dir=reports_dir,
+                        configured_model_log_path=configured_model_log_path,
+                        run_id_filter=run_id,
+                        include_linked_trace=False,
+                    )
+                    for session_dir in _sessions_for_run(haindy_home, run_id)
+                ]
+                if run_id
+                else []
+            )
     except FileNotFoundError as exc:
         print(str(exc), file=sys.stderr)
         return 1
 
-    summary = _summarize(trace_path, repo_root, data_root)
     print(json.dumps(summary, indent=2))
     return 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,7 @@ secrets/
 docs/prompt.md
 docs/plans/*
 !docs/plans/windows-support.md
+!docs/plans/haindy-test-forensics-tool-call.md
 !docs/plans/storage/
 !docs/plans/storage/unify-data-home.md
 docs/issues/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-04-23
+
+### Added
+
+- Regression coverage for the repo-local `haindy-test-forensics` artifact locator helper across configured data roots, reports directories, and tool-call session lookups
+
+### Fixed
+
+- Repo-local `haindy-test-forensics` guidance now covers tool-call sessions and distinguishes durable run artifacts from session-local evidence
+- The repo-local forensics helper now resolves effective `HAINDY_HOME`, `data_dir`, and `reports_dir` settings instead of assuming legacy repo-local artifact paths
+
 ## [0.4.1] - 2026-04-21
 
 ### Added

--- a/docs/plans/haindy-test-forensics-tool-call.md
+++ b/docs/plans/haindy-test-forensics-tool-call.md
@@ -1,0 +1,39 @@
+# Update HAINDY Test Forensics for Home Data and Tool-Call Sessions
+
+## Summary
+
+- Work on branch `feat/haindy-test-forensics-tool-call`.
+- Update the `haindy-test-forensics` skill and helper so they resolve current HAINDY artifact locations and support tool-call mode.
+- Chosen scope: full session coverage for tool-call `test`, `explore`, and one-off session evidence.
+- Use effective HAINDY settings only; do not silently fall back to old `./data` paths.
+
+## Key Changes
+
+- Update `.codex/skills/haindy-test-forensics/scripts/locate_run_artifacts.py` to load `settings.data_dir`, `settings.reports_dir`, and `settings.haindy_home`.
+- Extend the helper CLI with `--session-id <id>` and `--latest-session`; keep `--run-id`, `--latest`, and `--latest-failed`.
+- For batch and tool-call background `test`, resolve traces from `<data-root>/traces/<run_id>.json`, model logs from trace metadata or `settings.model_log_path`, and reports from `settings.reports_dir / run_id`.
+- For tool-call sessions, summarize `~/.haindy/sessions/<session-id>/session.json`, `action_artifacts/*.json`, `screenshots/`, `logs/daemon.log`, and `logs/ai_interactions.jsonl`; correlate to a trace when `latest_background_run_id` is present.
+- For `explore` or `act` sessions without a trace, return a valid session-focused summary instead of failing because no trace exists.
+- Update `SKILL.md` and `agents/openai.yaml` so the skill description, evidence order, workflow, examples, and output guidance distinguish durable data artifacts from session-local tool-call artifacts.
+- Keep legacy `./data` behavior explicit: mention that old artifacts require fixing/removing overrides, but do not auto-scan unconfigured legacy paths.
+
+## Implementation Approach
+
+- Verify the worktree before edits and avoid overwriting unrelated user changes.
+- Write this plan under `docs/plans/` before code edits.
+- Produce one JSON summary shape with optional fields for `run_id`, `session_id`, `mode`, `data_root`, `reports_dir`, `trace_path`, `model_log_path`, `session_dir`, `session_metadata_path`, `action_artifact_paths`, `session_screenshot_dir`, `daemon_log_path`, `ai_interactions_log_path`, failure summaries, and `rg` hints.
+- Selection rules: `--session-id` is session-first; `--run-id` is trace-first and then scans sessions for matching metadata/artifacts; `--latest-session` picks newest session metadata directory; default remains latest failed trace.
+- Self-review checkpoints: after each helper change, confirm the selected artifact root comes from settings; after each skill-doc change, confirm it tells the investigator which artifact is authoritative for batch test, tool-call test, and session-only explore/act.
+
+## Test Plan
+
+- Add pytest coverage for the helper script using temp `HAINDY_HOME`, `HAINDY_DATA_DIR`, and `HAINDY_REPORTS_DIR` values.
+- Cover default data-root trace lookup, exact data-dir override lookup, reports-dir override lookup, `--session-id` summary, `--run-id` session correlation, `--latest-session`, and a session-only no-trace case.
+- Cover the no-fallback policy by creating old `./data` artifacts while settings point elsewhere and asserting the helper does not choose them.
+- Run `.venv/bin/ruff check .`, `.venv/bin/ruff format .`, `.venv/bin/mypy haindy`, and `.venv/bin/pytest`.
+
+## Assumptions
+
+- Tool-call `test` remains the only tool-call flow guaranteed to have a durable run trace.
+- Session-only `explore` and `act` forensics should be best-effort from session metadata, screenshots, daemon logs, and AI interaction logs.
+- The implementation should not add compatibility fallbacks for old `./data`; it should make the current configured locations clear and fail loudly when artifacts are absent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haindy"
-version = "0.4.1"
+version = "0.4.2"
 description = "Autonomous AI Testing Agent with multi-agent architecture"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_haindy_test_forensics_helper.py
+++ b/tests/test_haindy_test_forensics_helper.py
@@ -1,0 +1,356 @@
+"""Tests for the HAINDY test-forensics artifact locator helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from haindy.config.settings import SETTINGS_ENV_VARS, build_project_data_dir
+
+_HELPER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".codex"
+    / "skills"
+    / "haindy-test-forensics"
+    / "scripts"
+    / "locate_run_artifacts.py"
+)
+
+
+@pytest.fixture
+def helper_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "haindy_test_forensics_locator",
+        _HELPER_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _isolate_haindy_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    for env_name in SETTINGS_ENV_VARS.values():
+        monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_trace(
+    data_root: Path,
+    run_id: str,
+    *,
+    success: bool = False,
+    model_log_path: Path | None = None,
+) -> Path:
+    trace_path = data_root / "traces" / f"{run_id}.json"
+    metadata: dict[str, object] = {
+        "automation_backend": "desktop",
+        "test_plan_name": "Forensics fixture",
+    }
+    if model_log_path is not None:
+        metadata["model_log_path"] = str(model_log_path)
+    _write_json(
+        trace_path,
+        {
+            "run_id": run_id,
+            "success": success,
+            "started_at": "2026-04-10T00:00:00Z",
+            "ended_at": "2026-04-10T00:00:10Z",
+            "run_metadata": metadata,
+            "steps": [
+                {
+                    "scenario": "Login",
+                    "step_number": 1,
+                    "step_action": "Tap login",
+                    "expected_result": "Dashboard appears",
+                    "step_result": {
+                        "status": "failed",
+                        "actual_result": "Login screen stayed visible",
+                        "error_message": None,
+                        "screenshot_before": "before.png",
+                        "screenshot_after": "after.png",
+                    },
+                }
+            ],
+        },
+    )
+    return trace_path
+
+
+def _write_session(
+    haindy_home: Path,
+    session_id: str,
+    *,
+    run_id: str | None = None,
+    created_at: str = "2026-04-10T00:00:00+00:00",
+) -> Path:
+    session_dir = haindy_home / "sessions" / session_id
+    latest_artifact = (
+        session_dir / "action_artifacts" / "case_step_001.json" if run_id else None
+    )
+    _write_json(
+        session_dir / "session.json",
+        {
+            "session_id": session_id,
+            "backend": "desktop",
+            "created_at": created_at,
+            "status": "ready",
+            "last_command_at": created_at,
+            "last_command_name": "test" if run_id else "explore",
+            "latest_screenshot_path": str(session_dir / "screenshots" / "step_001.png"),
+            "latest_background_run_id": run_id,
+            "latest_test_phase": "completed" if run_id else None,
+            "latest_test_progress_at": created_at if run_id else None,
+            "latest_test_action_artifact_path": (
+                str(latest_artifact) if latest_artifact else None
+            ),
+        },
+    )
+    (session_dir / "screenshots").mkdir(parents=True, exist_ok=True)
+    (session_dir / "screenshots" / "step_001.png").write_bytes(b"png")
+    (session_dir / "logs").mkdir(parents=True, exist_ok=True)
+    (session_dir / "logs" / "daemon.log").write_text("daemon\n", encoding="utf-8")
+    (session_dir / "logs" / "ai_interactions.jsonl").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    if latest_artifact:
+        _write_json(
+            latest_artifact,
+            {
+                "run_id": run_id,
+                "session_id": session_id,
+                "phase": "completed",
+            },
+        )
+    return session_dir
+
+
+def _run_helper(
+    helper_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+    *args: str,
+) -> tuple[int, dict[str, object], str]:
+    exit_code = helper_module.main(list(args))
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out) if captured.out.strip() else {}
+    return exit_code, payload, captured.err
+
+
+def test_run_id_uses_default_project_data_root(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    haindy_home = tmp_path / "haindy-home"
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("HAINDY_HOME", str(haindy_home))
+    data_root = build_project_data_dir(haindy_home, project_dir)
+    trace_path = _write_trace(data_root, "run_default")
+
+    exit_code, payload, stderr = _run_helper(
+        helper_module,
+        capsys,
+        "--run-id",
+        "run_default",
+    )
+
+    assert exit_code == 0
+    assert stderr == ""
+    assert payload["data_root"] == str(data_root)
+    assert payload["trace_path"] == str(trace_path)
+
+
+def test_latest_failed_uses_exact_data_dir_override(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_root = tmp_path / "configured-data"
+    monkeypatch.setenv("HAINDY_DATA_DIR", str(data_root))
+    _write_trace(data_root, "passed", success=True)
+    _write_trace(data_root, "failed", success=False)
+
+    exit_code, payload, _stderr = _run_helper(helper_module, capsys)
+
+    assert exit_code == 0
+    assert payload["run_id"] == "failed"
+    assert payload["data_root"] == str(data_root)
+
+
+def test_report_dir_uses_reports_dir_override(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_id = "run_reports"
+    data_root = tmp_path / "data"
+    reports_dir = tmp_path / "custom-reports"
+    monkeypatch.setenv("HAINDY_DATA_DIR", str(data_root))
+    monkeypatch.setenv("HAINDY_REPORTS_DIR", str(reports_dir))
+    _write_trace(data_root, run_id)
+    action_json = reports_dir / run_id / "run-actions.json"
+    html_report = reports_dir / run_id / "index.html"
+    action_json.parent.mkdir(parents=True)
+    action_json.write_text("{}", encoding="utf-8")
+    html_report.write_text("<html></html>", encoding="utf-8")
+
+    exit_code, payload, _stderr = _run_helper(
+        helper_module,
+        capsys,
+        "--run-id",
+        run_id,
+    )
+
+    assert exit_code == 0
+    assert payload["reports_dir"] == str(reports_dir)
+    assert payload["report_dir"] == str(reports_dir / run_id)
+    assert payload["actions_json_paths"] == [str(action_json)]
+    assert payload["html_report_paths"] == [str(html_report)]
+
+
+def test_session_id_links_session_artifacts_to_trace(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_id = "session-run"
+    data_root = tmp_path / "data"
+    haindy_home = tmp_path / "haindy-home"
+    monkeypatch.setenv("HAINDY_DATA_DIR", str(data_root))
+    monkeypatch.setenv("HAINDY_HOME", str(haindy_home))
+    _write_trace(data_root, run_id)
+    session_dir = _write_session(haindy_home, "session-a", run_id=run_id)
+
+    exit_code, payload, _stderr = _run_helper(
+        helper_module,
+        capsys,
+        "--session-id",
+        "session-a",
+    )
+
+    assert exit_code == 0
+    assert payload["mode"] == "tool_call_session"
+    assert payload["session_id"] == "session-a"
+    assert payload["session_dir"] == str(session_dir)
+    assert payload["action_artifact_paths"] == [
+        str(session_dir / "action_artifacts" / "case_step_001.json")
+    ]
+    linked_trace = payload["linked_trace"]
+    assert isinstance(linked_trace, dict)
+    assert linked_trace["run_id"] == run_id
+
+
+def test_run_id_summary_correlates_matching_tool_call_sessions(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_id = "correlated-run"
+    data_root = tmp_path / "data"
+    haindy_home = tmp_path / "haindy-home"
+    monkeypatch.setenv("HAINDY_DATA_DIR", str(data_root))
+    monkeypatch.setenv("HAINDY_HOME", str(haindy_home))
+    _write_trace(data_root, run_id)
+    _write_session(haindy_home, "matching-session", run_id=run_id)
+    _write_session(haindy_home, "other-session", run_id="other-run")
+
+    exit_code, payload, _stderr = _run_helper(
+        helper_module,
+        capsys,
+        "--run-id",
+        run_id,
+    )
+
+    assert exit_code == 0
+    sessions = payload["matching_tool_call_sessions"]
+    assert isinstance(sessions, list)
+    assert [session["session_id"] for session in sessions] == ["matching-session"]
+
+
+def test_latest_session_uses_newest_session_metadata(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    haindy_home = tmp_path / "haindy-home"
+    monkeypatch.setenv("HAINDY_HOME", str(haindy_home))
+    older = _write_session(haindy_home, "older")
+    newer = _write_session(haindy_home, "newer")
+    os.utime(older / "session.json", (100, 100))
+    os.utime(newer / "session.json", (200, 200))
+
+    exit_code, payload, _stderr = _run_helper(
+        helper_module,
+        capsys,
+        "--latest-session",
+    )
+
+    assert exit_code == 0
+    assert payload["session_id"] == "newer"
+
+
+def test_session_without_trace_still_returns_session_summary(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    haindy_home = tmp_path / "haindy-home"
+    data_root = tmp_path / "data"
+    monkeypatch.setenv("HAINDY_HOME", str(haindy_home))
+    monkeypatch.setenv("HAINDY_DATA_DIR", str(data_root))
+    _write_session(haindy_home, "explore-session")
+
+    exit_code, payload, _stderr = _run_helper(
+        helper_module,
+        capsys,
+        "--session-id",
+        "explore-session",
+    )
+
+    assert exit_code == 0
+    assert payload["run_id"] is None
+    assert payload["linked_trace"] is None
+    assert payload["action_artifact_paths"] == []
+
+
+def test_run_lookup_does_not_fall_back_to_legacy_data_dir(
+    helper_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    configured_data = tmp_path / "configured-data"
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("HAINDY_DATA_DIR", str(configured_data))
+    _write_trace(project_dir / "data", "legacy-run")
+
+    exit_code = helper_module.main(["--run-id", "legacy-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert f"under {configured_data / 'traces'}" in captured.err


### PR DESCRIPTION
## Summary
- update the repo-local `haindy-test-forensics` skill and locator helper for tool-call sessions and configured artifact roots
- add regression tests covering configured data roots, reports directories, and session/run correlation
- prepare `v0.4.2` by bumping the package version and adding the changelog entry

## Why
The repo-local forensics workflow still assumed older artifact locations and did not clearly handle tool-call session evidence. That made incident analysis harder for current HAINDY runs, especially when contributors were working from configured `HAINDY_HOME`, `HAINDY_DATA_DIR`, or `HAINDY_REPORTS_DIR` paths.

## Impact
Contributors can now investigate tool-call sessions and related batch runs with the current artifact layout instead of guessing paths or falling back to legacy repo-local assumptions.

This PR also prepares the branch for `v0.4.2` once it lands on `main`. The release scope here is repo-local forensics tooling and validation coverage rather than new installed runtime behavior.

## Root Cause
The repo-local skill guidance and helper script had drifted from the current HAINDY storage model and did not model tool-call session artifacts as first-class evidence.

## Validation
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy haindy`
- `.venv/bin/pytest`
- `.venv/bin/python -m build`
- `.venv/bin/python -c "import importlib.metadata as m; print(m.version('haindy'))"`
- `.venv/bin/haindy version`
