### PR TITLE
Fix Google mobile CU interactions tools

### DIFF
--- a/haindy/agents/computer_use/google_mixin.py
+++ b/haindy/agents/computer_use/google_mixin.py
@@ -849,6 +849,16 @@ class GoogleComputerUseMixin:
             tools.extend(self._google_modifier_click_function_tools())
         return tools
 
+    @staticmethod
+    def _google_interactions_needs_raw_tools(tools: Any) -> bool:
+        """Return whether tools must bypass SDK field alias conversion."""
+        if not isinstance(tools, list):
+            return False
+        return any(
+            isinstance(tool, dict) and "excluded_predefined_functions" in tool
+            for tool in tools
+        )
+
     def _build_google_follow_up_item(
         self: _ComputerUseSession,
         call_result: Any,
@@ -1239,6 +1249,16 @@ class GoogleComputerUseMixin:
             key: value for key, value in payload.items() if key != "api_surface"
         }
 
+        def _interaction_create_kwargs() -> dict[str, Any]:
+            kwargs = dict(request_payload)
+            tools = kwargs.get("tools")
+            if not self._google_interactions_needs_raw_tools(tools):
+                return kwargs
+
+            kwargs.pop("tools", None)
+            kwargs["extra_body"] = {"tools": tools}
+            return kwargs
+
         def _call_generate_content() -> Any:
             if hasattr(client, "models") and hasattr(client.models, "generate_content"):
                 contents = request_payload.get("contents") or request_payload.get(
@@ -1268,12 +1288,16 @@ class GoogleComputerUseMixin:
                     )
 
                 if hasattr(client, "aio") and hasattr(client.aio, "interactions"):
-                    return await client.aio.interactions.create(**request_payload)
+                    return await client.aio.interactions.create(
+                        **_interaction_create_kwargs()
+                    )
                 if hasattr(client, "interactions") and hasattr(
                     client.interactions, "create"
                 ):
                     return await self._invoke_google_request(
-                        lambda: client.interactions.create(**request_payload)
+                        lambda: client.interactions.create(
+                            **_interaction_create_kwargs()
+                        )
                     )
             raise ComputerUseExecutionError(
                 "Google GenAI client does not support interactions.create calls."

--- a/tests/test_computer_use_session_google_runtime.py
+++ b/tests/test_computer_use_session_google_runtime.py
@@ -446,6 +446,37 @@ async def test_google_interactions_failure_logs_payload_summary(
 
 
 @pytest.mark.asyncio
+async def test_google_mobile_interactions_tools_bypass_sdk_alias_transform(
+    mock_client, mock_browser, session_settings
+):
+    session_settings.cu_provider = "google"
+    interactions_create = AsyncMock(return_value={"id": "ok"})
+    session = make_session(
+        mock_client=mock_client,
+        mock_browser=mock_browser,
+        session_settings=session_settings,
+        provider="google",
+        google_client=make_google_client(interactions_create_mock=interactions_create),
+    )
+    tools = session._build_google_interaction_tools("mobile_adb")
+
+    response = await session._create_google_response(
+        {
+            "api_surface": "interactions",
+            "model": "gemini-3-flash-preview",
+            "input": [{"type": "text", "text": "status"}],
+            "tools": tools,
+        }
+    )
+
+    assert response == {"id": "ok"}
+    kwargs = interactions_create.await_args.kwargs
+    assert "tools" not in kwargs
+    assert kwargs["extra_body"]["tools"] == tools
+    assert "excluded_predefined_functions" in kwargs["extra_body"]["tools"][0]
+
+
+@pytest.mark.asyncio
 async def test_google_computer_use_logs_non_retryable_failed_attempt(
     mock_client, mock_browser, session_settings
 ):


### PR DESCRIPTION
## Summary

Fixes Google Computer Use mobile Interactions requests when HAINDY excludes desktop-only predefined functions.

HAINDY builds the documented Python-side `excluded_predefined_functions` field for mobile Google CU tools, but `google-genai` aliases that nested key to `excludedPredefinedFunctions` before sending an Interactions request. The live Interactions endpoint rejected that transformed field with an unknown-parameter 400. This change sends mobile Interactions tools through `extra_body` when that field is present so the SDK does not rewrite the nested tool declaration.

## Impact

- Keeps the existing Python-side tool shape used by HAINDY tests and helpers.
- Avoids the `excludedPredefinedFunctions` / `excluded_predefined_functions` mismatch in live Google CU mobile/iOS sessions.
- Leaves non-mobile and non-Interactions Google calls unchanged.

## Validation

- `ruff check .` passed
- `ruff format .` passed, no files changed
- Targeted Google CU tests passed: `38 passed`
- Live iOS HAINDY session verified: `haindy session status` succeeded on session `2a812ce1-aeaf-4c10-90ca-638df15e817c` and no old Google 400 parameter error appeared in the daemon log
- Pre-commit passed for the commit

Known unrelated existing failures observed during broader validation:

- `mypy haindy` reported pre-existing macOS/Windows screen capture type errors
- Full `pytest` had 2 unrelated failures: `tests/test_ios_driver.py::test_ios_driver_screenshot_invalid_png_raises` and `tests/test_tool_call_mode_launcher.py::test_tool_call_daemon_survives_session_new_process_exit`
