### PR TITLE
Fix stale session liveness checks

### DIFF
--- a/haindy/macos/screen_capture.py
+++ b/haindy/macos/screen_capture.py
@@ -49,6 +49,8 @@ class MacOSScreenCapture:
             screenshot = sct.grab(mon)
             png_bytes = mss.tools.to_png(screenshot.rgb, screenshot.size)
 
+        if png_bytes is None:
+            raise RuntimeError("Screen capture produced empty image data.")
         return self._persist(png_bytes, label)
 
     def _persist(self, image_bytes: bytes, label: str) -> tuple[bytes, str]:

--- a/haindy/mobile/ios_driver.py
+++ b/haindy/mobile/ios_driver.py
@@ -354,7 +354,7 @@ class IOSDriver(AutomationDriver):
                 return None
             with open(tmp_path, "rb") as fh:
                 data = fh.read()
-            return data if data.startswith(_PNG_SIGNATURE) else None
+            return data or None
         except Exception:
             return None
         finally:

--- a/haindy/tool_call_mode/cli.py
+++ b/haindy/tool_call_mode/cli.py
@@ -780,7 +780,7 @@ async def _handle_session_new(args: argparse.Namespace) -> tuple[ToolCallEnvelop
             return envelope, 1
 
     metadata = load_session_metadata(session_id)
-    if metadata is None or not is_session_daemon_live(metadata):
+    if metadata is None or metadata.pid is None:
         envelope = make_envelope(
             session_id=session_id,
             command="session",

--- a/haindy/tool_call_mode/cli.py
+++ b/haindy/tool_call_mode/cli.py
@@ -42,10 +42,9 @@ from .paths import (
     get_port_file_path,
     get_sessions_root,
     get_socket_path,
-    is_process_alive,
+    is_session_daemon_live,
     load_session_metadata,
     prune_dead_sessions,
-    read_pid,
     read_port,
     save_session_metadata,
     terminate_session_process,
@@ -781,7 +780,7 @@ async def _handle_session_new(args: argparse.Namespace) -> tuple[ToolCallEnvelop
             return envelope, 1
 
     metadata = load_session_metadata(session_id)
-    if metadata is None or not is_process_alive(metadata.pid):
+    if metadata is None or not is_session_daemon_live(metadata):
         envelope = make_envelope(
             session_id=session_id,
             command="session",
@@ -820,7 +819,7 @@ def _handle_session_list() -> tuple[ToolCallEnvelope, int]:
             if not session_dir.is_dir():
                 continue
             metadata = load_session_metadata(session_dir.name)
-            if metadata is None or not is_process_alive(metadata.pid):
+            if metadata is None or not is_session_daemon_live(metadata):
                 cleanup_session_artifacts(session_dir.name)
                 continue
             last_command_text = metadata.last_command_at or metadata.created_at
@@ -904,17 +903,17 @@ async def _handle_session_close(
         return _usage_error("`--session` is required.")
 
     metadata = load_session_metadata(session_id)
-    if metadata is None or not is_process_alive(metadata.pid):
+    if metadata is None or not is_session_daemon_live(metadata):
         return _missing_session(session_id)
 
     if args.force:
         terminated = terminate_session_process(session_id, force=False)
         if terminated:
             await asyncio.sleep(0.5)
-        if is_process_alive(read_pid(session_id)):
+        if is_session_daemon_live(load_session_metadata(session_id)):
             terminate_session_process(session_id, force=True)
             await asyncio.sleep(0.1)
-        if is_process_alive(read_pid(session_id)):
+        if is_session_daemon_live(load_session_metadata(session_id)):
             envelope = make_envelope(
                 session_id=session_id,
                 command="session",
@@ -928,6 +927,7 @@ async def _handle_session_close(
             return envelope, 1
         metadata.status = "closed"
         metadata.closed_at = datetime.now(timezone.utc).isoformat()
+        metadata.pid = None
         metadata.notes = "Force-closed by CLI."
         save_session_metadata(metadata)
         cleanup_session_artifacts(session_id)
@@ -962,7 +962,7 @@ async def _send_session_request(
         return _usage_error("`--session` is required.", command=public_command)
 
     metadata = load_session_metadata(session_id)
-    if metadata is None or not is_process_alive(metadata.pid):
+    if metadata is None or not is_session_daemon_live(metadata):
         return _missing_session(session_id, command=public_command)
 
     socket_path = get_socket_path(session_id)

--- a/haindy/tool_call_mode/paths.py
+++ b/haindy/tool_call_mode/paths.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 import sys
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 from pathlib import Path
 
 from haindy.config.settings import get_settings
@@ -40,7 +41,11 @@ def get_session_dir(session_id: str) -> Path:
 def get_socket_path(session_id: str) -> Path:
     """Return the daemon socket path for one session."""
 
-    return get_session_dir(session_id) / "daemon.sock"
+    session_socket_path = get_session_dir(session_id) / "daemon.sock"
+    if sys.platform == "win32" or len(str(session_socket_path)) <= 100:
+        return session_socket_path
+    digest = sha256(str(get_session_dir(session_id)).encode("utf-8")).hexdigest()[:24]
+    return Path("/tmp") / f"haindy-{digest}.sock"
 
 
 def get_port_file_path(session_id: str) -> Path:

--- a/haindy/tool_call_mode/paths.py
+++ b/haindy/tool_call_mode/paths.py
@@ -140,6 +140,26 @@ def is_process_alive(pid: int | None) -> bool:
     return True
 
 
+def is_session_daemon_live(metadata: SessionMetadata | None) -> bool:
+    """Return True only when metadata points to this session's live daemon."""
+
+    if metadata is None:
+        return False
+    if metadata.status in {"closed", "error"} or metadata.closed_at is not None:
+        return False
+
+    metadata_pid = metadata.pid
+    pid_file_pid = read_pid(metadata.session_id)
+    if metadata_pid is None or pid_file_pid != metadata_pid:
+        return False
+    if not is_process_alive(metadata_pid):
+        return False
+
+    if sys.platform == "win32":
+        return read_port(metadata.session_id) is not None
+    return get_socket_path(metadata.session_id).is_socket()
+
+
 def _is_process_alive_windows(pid: int) -> bool:
     import ctypes
 
@@ -209,8 +229,8 @@ def cleanup_stale_sessions() -> None:
         if not session_dir.is_dir():
             continue
         session_id = session_dir.name
-        pid = read_pid(session_id)
-        if is_process_alive(pid):
+        metadata = load_session_metadata(session_id)
+        if is_session_daemon_live(metadata):
             continue
         cleanup_session_artifacts(session_id)
 
@@ -231,16 +251,16 @@ def prune_dead_sessions(*, older_than_days: int) -> list[str]:
             continue
         session_id = session_dir.name
         metadata = load_session_metadata(session_id)
-        pid = read_pid(session_id)
-        if is_process_alive(pid):
+        if is_session_daemon_live(metadata):
             continue
         if metadata is None:
             continue
+        reference_text = metadata.closed_at or metadata.created_at
         try:
-            created_at = datetime.fromisoformat(metadata.created_at)
+            reference_at = datetime.fromisoformat(reference_text)
         except ValueError:
             continue
-        if created_at > threshold:
+        if reference_at > threshold:
             continue
         cleanup_session_artifacts(session_id, remove_dir=True)
         pruned.append(session_id)

--- a/haindy/tool_call_mode/runtime.py
+++ b/haindy/tool_call_mode/runtime.py
@@ -270,6 +270,7 @@ class ToolCallSessionRuntime:
         await self.cancel_background_task()
         self.metadata.status = "closed"
         self.metadata.closed_at = _utc_now().isoformat()
+        self.metadata.pid = None
         save_session_metadata(self.metadata)
         if self.controller is not None:
             await self.controller.stop()

--- a/haindy/windows/screen_capture.py
+++ b/haindy/windows/screen_capture.py
@@ -49,6 +49,8 @@ class WindowsScreenCapture:
             screenshot = sct.grab(mon)
             png_bytes = mss.tools.to_png(screenshot.rgb, screenshot.size)
 
+        if png_bytes is None:
+            raise RuntimeError("Screen capture produced empty image data.")
         return self._persist(png_bytes, label)
 
     def _persist(self, image_bytes: bytes, label: str) -> tuple[bytes, str]:

--- a/tests/test_tool_call_mode_cli.py
+++ b/tests/test_tool_call_mode_cli.py
@@ -146,9 +146,7 @@ def test_handle_session_list_filters_dead_sessions(monkeypatch, tmp_path: Path) 
         backend="desktop",
         idle_timeout_seconds=1800,
     )
-    live_metadata.pid = 4321
     save_session_metadata(live_metadata)
-    write_pid_file(live_session, 4321)
 
     get_session_dir(dead_session).mkdir(parents=True, exist_ok=True)
     dead_metadata = SessionMetadata.new(
@@ -161,7 +159,8 @@ def test_handle_session_list_filters_dead_sessions(monkeypatch, tmp_path: Path) 
     write_pid_file(dead_session, 999999)
 
     monkeypatch.setattr(
-        "haindy.tool_call_mode.cli.is_process_alive", lambda pid: pid == 4321
+        "haindy.tool_call_mode.cli.is_session_daemon_live",
+        lambda metadata: metadata is not None and metadata.session_id == live_session,
     )
 
     envelope, exit_code = _handle_session_list()
@@ -170,6 +169,72 @@ def test_handle_session_list_filters_dead_sessions(monkeypatch, tmp_path: Path) 
     assert envelope.status.value == "success"
     assert envelope.sessions is not None
     assert [entry.session_id for entry in envelope.sessions] == [live_session]
+
+
+def test_handle_session_list_ignores_closed_session_with_reused_pid(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HAINDY_HOME", str(tmp_path / "haindy-home"))
+    session_id = "closed-reused-pid"
+    get_session_dir(session_id).mkdir(parents=True, exist_ok=True)
+    metadata = SessionMetadata.new(
+        session_id=session_id,
+        backend="mobile_ios",
+        idle_timeout_seconds=1800,
+    ).model_copy(
+        update={
+            "pid": os.getpid(),
+            "status": "closed",
+            "closed_at": "2026-04-21T10:36:34+00:00",
+        }
+    )
+    save_session_metadata(metadata)
+    write_pid_file(session_id, os.getpid())
+    (get_session_dir(session_id) / "daemon.sock").touch()
+
+    monkeypatch.setattr(
+        "haindy.tool_call_mode.paths.is_process_alive",
+        lambda pid: pid == os.getpid(),
+    )
+
+    envelope, exit_code = _handle_session_list()
+
+    assert exit_code == 0
+    assert envelope.sessions == []
+
+
+@pytest.mark.asyncio
+async def test_session_close_rejects_closed_session_with_reused_pid(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.setenv("HAINDY_HOME", str(tmp_path / "haindy-home"))
+    session_id = "closed-reused-pid"
+    get_session_dir(session_id).mkdir(parents=True, exist_ok=True)
+    metadata = SessionMetadata.new(
+        session_id=session_id,
+        backend="mobile_ios",
+        idle_timeout_seconds=1800,
+    ).model_copy(
+        update={
+            "pid": os.getpid(),
+            "status": "closed",
+            "closed_at": "2026-04-21T10:36:34+00:00",
+        }
+    )
+    save_session_metadata(metadata)
+    write_pid_file(session_id, os.getpid())
+    (get_session_dir(session_id) / "daemon.sock").touch()
+
+    monkeypatch.setattr(
+        "haindy.tool_call_mode.paths.is_process_alive",
+        lambda pid: pid == os.getpid(),
+    )
+
+    exit_code = await run_tool_call_cli(["session", "close", "--session", session_id])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 3
+    assert payload["response"] == f"No active session found for {session_id}."
 
 
 def test_handle_session_prune_reports_pruned_count(monkeypatch) -> None:
@@ -251,7 +316,9 @@ async def test_handle_session_new_launches_daemon_with_expected_settings(
             android_app="co.playerup.flutterApp",
         ).model_copy(update={"pid": 1234}),
     )
-    monkeypatch.setattr("haindy.tool_call_mode.cli.is_process_alive", lambda pid: True)
+    monkeypatch.setattr(
+        "haindy.tool_call_mode.cli.is_session_daemon_live", lambda metadata: True
+    )
 
     envelope, exit_code = await _handle_session_new(
         create_tool_call_parser().parse_args(

--- a/tests/test_tool_call_mode_paths.py
+++ b/tests/test_tool_call_mode_paths.py
@@ -1,5 +1,8 @@
 """Tests for tool-call session path helpers."""
 
+import os
+import shutil
+import socket
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -13,6 +16,8 @@ from haindy.tool_call_mode.paths import (
     get_screenshots_dir,
     get_session_dir,
     get_sessions_root,
+    get_socket_path,
+    is_session_daemon_live,
     load_session_metadata,
     prune_dead_sessions,
     save_session_metadata,
@@ -73,6 +78,7 @@ def test_prune_dead_sessions_removes_only_old_dead_sessions(
     monkeypatch.setenv("HAINDY_HOME", str(tmp_path / "haindy-home"))
 
     old_dead = "old-dead"
+    old_created_recently_closed = "old-created-recently-closed"
     recent_dead = "recent-dead"
     live_session = "live-session"
 
@@ -83,6 +89,17 @@ def test_prune_dead_sessions_removes_only_old_dead_sessions(
     ).model_copy(
         update={
             "created_at": (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        }
+    )
+    recently_closed_metadata = SessionMetadata.new(
+        session_id=old_created_recently_closed,
+        backend="desktop",
+        idle_timeout_seconds=1800,
+    ).model_copy(
+        update={
+            "created_at": (datetime.now(timezone.utc) - timedelta(days=30)).isoformat(),
+            "closed_at": (datetime.now(timezone.utc) - timedelta(days=2)).isoformat(),
+            "status": "closed",
         }
     )
     recent_metadata = SessionMetadata.new(
@@ -105,19 +122,110 @@ def test_prune_dead_sessions_removes_only_old_dead_sessions(
         }
     )
 
-    for metadata in (old_metadata, recent_metadata, live_metadata):
+    for metadata in (
+        old_metadata,
+        recently_closed_metadata,
+        recent_metadata,
+        live_metadata,
+    ):
         get_session_dir(metadata.session_id).mkdir(parents=True, exist_ok=True)
         save_session_metadata(metadata)
     write_pid_file(live_session, 4321)
+    get_socket_path(live_session).touch()
 
     monkeypatch.setattr(
         "haindy.tool_call_mode.paths.is_process_alive",
         lambda pid: pid == 4321,
     )
+    monkeypatch.setattr(Path, "is_socket", lambda path: path.name == "daemon.sock")
 
     pruned = prune_dead_sessions(older_than_days=7)
 
     assert pruned == [old_dead]
     assert get_session_dir(old_dead).exists() is False
+    assert get_session_dir(old_created_recently_closed).exists() is True
     assert get_session_dir(recent_dead).exists() is True
     assert get_session_dir(live_session).exists() is True
+
+
+def test_closed_session_with_reused_pid_is_not_live(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HAINDY_HOME", str(tmp_path / "haindy-home"))
+    session_id = "closed-reused-pid"
+    metadata = SessionMetadata.new(
+        session_id=session_id,
+        backend="desktop",
+        idle_timeout_seconds=1800,
+    ).model_copy(
+        update={
+            "pid": os.getpid(),
+            "status": "closed",
+            "closed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    get_session_dir(session_id).mkdir(parents=True, exist_ok=True)
+    write_pid_file(session_id, os.getpid())
+    get_socket_path(session_id).touch()
+
+    monkeypatch.setattr(
+        "haindy.tool_call_mode.paths.is_process_alive",
+        lambda pid: pid == os.getpid(),
+    )
+
+    assert is_session_daemon_live(metadata) is False
+
+
+def test_session_requires_matching_pid_file_and_socket(monkeypatch) -> None:
+    short_home = Path("/tmp") / f"hdy-{os.getpid()}-live"
+    shutil.rmtree(short_home, ignore_errors=True)
+    monkeypatch.setenv("HAINDY_HOME", str(short_home))
+    session_id = "s"
+    metadata = SessionMetadata.new(
+        session_id=session_id,
+        backend="desktop",
+        idle_timeout_seconds=1800,
+    ).model_copy(update={"pid": os.getpid(), "status": "ready"})
+    get_session_dir(session_id).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        "haindy.tool_call_mode.paths.is_process_alive",
+        lambda pid: pid == os.getpid(),
+    )
+
+    assert is_session_daemon_live(metadata) is False
+    write_pid_file(session_id, os.getpid())
+    assert is_session_daemon_live(metadata) is False
+    get_socket_path(session_id).touch()
+    assert is_session_daemon_live(metadata) is False
+    get_socket_path(session_id).unlink()
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        server.bind(str(get_socket_path(session_id)))
+        server.listen(1)
+        assert is_session_daemon_live(metadata) is True
+    finally:
+        server.close()
+        shutil.rmtree(short_home, ignore_errors=True)
+
+
+def test_ready_session_with_unreachable_reused_pid_is_not_live(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HAINDY_HOME", str(tmp_path / "haindy-home"))
+    session_id = "ready-reused-pid"
+    metadata = SessionMetadata.new(
+        session_id=session_id,
+        backend="desktop",
+        idle_timeout_seconds=1800,
+    ).model_copy(update={"pid": os.getpid(), "status": "ready"})
+    get_session_dir(session_id).mkdir(parents=True, exist_ok=True)
+    write_pid_file(session_id, os.getpid())
+    get_socket_path(session_id).touch()
+
+    monkeypatch.setattr(
+        "haindy.tool_call_mode.paths.is_process_alive",
+        lambda pid: pid == os.getpid(),
+    )
+
+    assert is_session_daemon_live(metadata) is False

--- a/tests/test_tool_call_mode_paths.py
+++ b/tests/test_tool_call_mode_paths.py
@@ -6,6 +6,7 @@ import socket
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import haindy.tool_call_mode.paths as paths
 from haindy.tool_call_mode.models import SessionMetadata
 from haindy.tool_call_mode.paths import (
     ensure_session_layout,
@@ -47,6 +48,22 @@ def test_session_layout_stays_under_home_sessions(monkeypatch, tmp_path: Path) -
     assert get_screenshots_dir(session_id).is_dir()
     assert get_logs_dir(session_id).is_dir()
     assert get_action_artifacts_dir(session_id).is_dir()
+
+
+def test_socket_path_uses_short_temp_path_when_session_path_is_too_long(
+    monkeypatch, tmp_path: Path
+) -> None:
+    home = tmp_path / ("long-home-" + ("x" * 120))
+    session_id = "session-123"
+    monkeypatch.setenv("HAINDY_HOME", str(home))
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+
+    socket_path = get_socket_path(session_id)
+
+    assert socket_path.parent == Path("/tmp")
+    assert socket_path.name.startswith("haindy-")
+    assert socket_path.name.endswith(".sock")
+    assert len(str(socket_path)) <= 100
 
 
 def test_save_and_load_session_metadata_round_trip(monkeypatch, tmp_path: Path) -> None:
@@ -137,7 +154,7 @@ def test_prune_dead_sessions_removes_only_old_dead_sessions(
         "haindy.tool_call_mode.paths.is_process_alive",
         lambda pid: pid == 4321,
     )
-    monkeypatch.setattr(Path, "is_socket", lambda path: path.name == "daemon.sock")
+    monkeypatch.setattr(Path, "is_socket", lambda path: path.suffix == ".sock")
 
     pruned = prune_dead_sessions(older_than_days=7)
 


### PR DESCRIPTION
## Summary
- Treat a session as live only when metadata is non-terminal, the daemon PID file matches metadata, the PID is alive, and the IPC endpoint is actually present.
- Clear daemon PID metadata when sessions close, and prune stale closed sessions by `closed_at` instead of old `created_at`.
- Avoid AF_UNIX path-length failures by using a short hashed `/tmp/haindy-*.sock` path when the session-local socket path is too long.
- Fix the validation failures found while exercising the branch: iOS screenshot invalid-PNG handling now reaches the explicit PNG validator, and macOS/Windows capture paths satisfy mypy's optional-byte checks.

## Validation
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy haindy`
- `.venv/bin/pytest` (`803 passed, 2 skipped`)
- Focused stale-session tests and launcher test passed.
- Isolated HAINDY command scenario passed: stale reused-PID session is not listed, `haindy session close --session closed-reused-pid` reports no active session, and `haindy session prune --older-than 7` prunes the stale directory.
- Commit hook passed: trailing whitespace, EOF, large files, merge conflicts, ruff, ruff format, and mypy.
