### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-05-20
+
+### Changed
+
+- Updated default OpenAI models to `gpt-5.5` and Anthropic models to `claude-opus-4-7`, with migration support for previous default model names in existing settings.
+- Refreshed provider and development dependencies, including `openai>=2.36.0`, `google-genai>=2.0.1`, `anthropic>=0.100.0`, and `mypy==2.0.0`.
+
+### Fixed
+
+- Google Computer Use now extracts function calls and assistant text from the current Interactions API `steps[]` response schema, restoring execution for `click_at` and related tool calls returned by Gemini.
+- Execute-mode Computer Use actions now fail with `no_executable_action` when the provider returns no executable action, instead of reporting a successful no-op.
+
 ## [0.6.0] - 2026-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Under the hood, each action goes through a computer-use AI provider (OpenAI, Goo
 
 Use `test` when the scenario is backed by written requirements, a test plan, wireframes, or other explicit documentation and you want structured execution plus validation. Use `explore` when the goal is clear but the path is not, or when you are working from product knowledge rather than supporting docs. Use `act` when you want tight step-by-step control and to inspect the screen after each command.
 
+For execute-mode commands such as `act`, HAINDY reports a failure if the computer-use provider returns no executable action for the requested step.
+
 ### Session variables
 
 Store values your agent can reference across commands:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -228,6 +228,7 @@ Operational rules:
 - `session new` launches the daemon independently and returns only after the socket is ready
 - Desktop `session new --url ...` is still deferred
 - `test` and `explore` are async dispatch commands; poll `test-status` or `explore-status` for terminal results
+- Execute-mode actions fail with `no_executable_action` when the computer-use provider returns no executable action
 - While a background task is active, `act`, `session status`, `test`, and `explore` return `session_busy`
 - While a background task is active, `test-status`, `explore-status`, `screenshot`, `session set`, `session unset`, `session vars`, and `session close` remain available
 - `session close` cancels an active background task before shutting the daemon down

--- a/haindy/agents/action_agent.py
+++ b/haindy/agents/action_agent.py
@@ -1187,6 +1187,18 @@ Respond with JSON only:
             visual_frame=artifact_frame,
         )
 
+        if (
+            interaction_mode == "execute"
+            and session_result.terminal_status != "failed"
+            and not session_result.actions
+        ):
+            session_result.terminal_status = "failed"
+            session_result.terminal_failure_code = "no_executable_action"
+            session_result.terminal_failure_reason = (
+                "Computer Use provider returned no executable action for an "
+                "execute-mode step; refusing to treat the step as successful."
+            )
+
         failing_action = next(
             (
                 action

--- a/haindy/tool_call_mode/runtime.py
+++ b/haindy/tool_call_mode/runtime.py
@@ -1429,6 +1429,7 @@ class ToolCallSessionRuntime:
             "observe_only_policy_violation",
             "google_prompt_blocked",
             "google_ambiguous_function_call_batch",
+            "no_executable_action",
             "safety_fail_fast",
             "safety_policy",
         }:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haindy"
-version = "0.6.0"
+version = "0.6.1"
 description = "Autonomous AI Testing Agent with multi-agent architecture"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_action_agent.py
+++ b/tests/test_action_agent.py
@@ -10,6 +10,7 @@ from haindy.agents.action_agent import ActionAgent
 from haindy.agents.computer_use.types import ComputerUseSessionResult
 from haindy.agents.computer_use.visual_state import VisualBounds, VisualFrame
 from haindy.core.enhanced_types import (
+    ComputerToolTurn,
     EnhancedActionResult,
     ExecutionResult,
     ValidationResult,
@@ -265,6 +266,13 @@ async def test_execute_action_persists_artifact_frame_instead_of_model_patch(
     class _FakeSession:
         async def run(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
             return ComputerUseSessionResult(
+                actions=[
+                    ComputerToolTurn(
+                        call_id="call_1",
+                        action_type="type_text_at",
+                        status="executed",
+                    )
+                ],
                 final_output="Done",
                 final_visual_frame=visual_patch,
                 final_artifact_frame=artifact_frame,
@@ -305,6 +313,58 @@ async def test_execute_action_persists_artifact_frame_instead_of_model_patch(
     assert result.environment_state_after.screenshot == b"artifact_full_png"
     assert result.environment_state_after.frame_kind == "keyframe"
     assert result.environment_state_after.patch_bounds is None
+
+
+@pytest.mark.asyncio
+async def test_execute_action_fails_when_execute_mode_returns_no_computer_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_settings(monkeypatch)
+    monkeypatch.setattr("haindy.agents.action_agent.get_debug_logger", lambda: None)
+
+    class _FakeSession:
+        async def run(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return ComputerUseSessionResult(response_ids=["resp_no_action"])
+
+    agent = ActionAgent(
+        automation_driver=SimpleNamespace(  # type: ignore[arg-type]
+            screenshot=AsyncMock(return_value=b"after_png"),
+            get_page_url=AsyncMock(return_value="https://example.com"),
+            get_page_title=AsyncMock(return_value="Example"),
+            get_viewport_size=AsyncMock(return_value=(1280, 720)),
+        )
+    )
+    monkeypatch.setattr(
+        agent, "_new_computer_use_session", lambda *_args, **_kwargs: _FakeSession()
+    )
+
+    step = TestStep(
+        step_number=6,
+        description="Click submit",
+        action="click submit",
+        expected_result="Submitted",
+        action_instruction=ActionInstruction(
+            action_type=ActionType.CLICK,
+            description="Click submit",
+            expected_outcome="Submitted",
+        ),
+    )
+
+    result = await agent.execute_action(
+        step,
+        {"environment": "desktop"},
+        screenshot=b"initial_png",
+    )
+
+    assert result.overall_success is False
+    assert result.failure_phase == "execution"
+    assert result.validation.valid is False
+    assert result.execution is not None
+    assert result.execution.success is False
+    assert result.terminal_failure_code == "no_executable_action"
+    assert result.terminal_failure_reason is not None
+    assert "no executable action" in result.terminal_failure_reason
+    assert result.computer_actions == []
 
 
 def _patch_settings_for_cu_client(

--- a/tests/test_tool_call_mode_runtime.py
+++ b/tests/test_tool_call_mode_runtime.py
@@ -196,6 +196,20 @@ def _make_action_result(
     )
 
 
+def test_runtime_maps_no_executable_action_to_agent_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = _make_runtime(monkeypatch, tmp_path)
+    result = _make_action_result("click the button", screenshot=b"after", success=False)
+    result.terminal_failure_code = "no_executable_action"
+    result.terminal_failure_reason = (
+        "Computer Use provider returned no executable action."
+    )
+
+    assert runtime._action_failure_reason(result) == ExitReason.AGENT_ERROR
+
+
 async def _wait_for_test_status(
     runtime: ToolCallSessionRuntime,
     *,


### PR DESCRIPTION
## What changed

- Bumps HAINDY to `0.6.1` and adds the changelog entry for the release.
- Documents execute-mode behavior for `act`/Computer Use when providers return no executable action.
- Makes execute-mode Computer Use fail with `no_executable_action` instead of reporting a successful no-op when no computer actions are returned.
- Maps `no_executable_action` to `agent_error` in tool-call mode envelopes.

## Why

The current PyPI release is behind main for the Google Interactions API `steps[]` response handling. While preparing that release, we also found the no-op success case: if a provider returned no executable action, `act` could still surface success because there was no failed action to inspect.

## Validation

- `.venv/bin/pip install -r requirements.lock && .venv/bin/pip install -e ".[dev]"`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format .`
- `.venv/bin/mypy haindy`
- `.venv/bin/pytest` (`802 passed, 4 skipped`)
- `.venv/bin/python -m build`
- `.venv/bin/python -c "import importlib.metadata as m; print(m.version('haindy'))"` -> `0.6.1`
- `.venv/bin/haindy version` -> `Version: 0.6.1`

## Manual self-regression

Original CU provider: `openai`; restored after testing.

| Provider | Surface | Session ID | Result | Notes |
|---|---|---|---|---|
| google | desktop | `9d047591-d884-4790-ada8-5f65b4812358` | Pass | `explore` reached `goal_reached`; `act` completed with one action. |
| openai | desktop | `db49796b-0358-4a0c-bfd4-dcc3a24aea45` | Pass | `explore` reached `goal_reached`; `act` completed with two actions. |
| anthropic | desktop | `e6c02eec-fab5-4a1f-a682-82427697a476` | Pass | `explore` reached `goal_reached`; `act` completed with one action. |
| current provider | android | `6190eb41-1ddf-4fdf-ac9b-fc2844658525` | Not run | `haindy session new --android` returned `Session daemon exited during startup. Check /home/fkeegan/.haindy/sessions/6190eb41-1ddf-4fdf-ac9b-fc2844658525/logs/daemon.log.` |
| current provider | ios | `63028968-9ff8-4187-995e-68a5556d7b01` | Not run | `haindy session new --ios` returned `Session daemon exited during startup. Check /home/fkeegan/.haindy/sessions/63028968-9ff8-4187-995e-68a5556d7b01/logs/daemon.log.` |

`haindy session list` reported `0 active sessions found` after cleanup. No release tag has been created yet; tag/publish should happen after this PR is reviewed and merged.
